### PR TITLE
Issue 314

### DIFF
--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -2302,16 +2302,6 @@ namespace Acam {
       // close the Andor
       //
       error |= this->camera.close();
-
-      // close the database connection
-      // this may throw an exception
-      //
-      try { this->database.close(); }
-      catch ( const std::exception &e ) {
-        message.str(""); message << "ERROR " << e.what();
-        logwrite( function, message.str() );
-        return ERROR;
-      }
     }
 
     // close connection to tcsd

--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -3793,9 +3793,8 @@ logwrite( function, message.str() );
     try {
       iface->database.write();
     }
-    catch ( ... ) {
-      logwrite( function, "ERROR writing to database" );
-//    error=ERROR; removed 12/12/2024 -- don't let database errors stop anything
+    catch ( const std::exception &e ) {
+      logwrite( function, "ERROR writing to database: "+std::string(e.what()) );
     }
 
     return error;

--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -3791,7 +3791,7 @@ logwrite( function, message.str() );
     // then will clear the map object once they are written.
     //
     try {
-      iface->database.write();
+      iface->database.insert();
     }
     catch ( const std::exception &e ) {
       logwrite( function, "ERROR writing to database: "+std::string(e.what()) );
@@ -4616,7 +4616,7 @@ logwrite( function, message.str() );
           this->database.add_key_val( "obs_id",   123 );
           this->database.add_key_val( "airmass",   1.23 );
           this->database.add_key_val( "acquired",   true );
-          this->database.write();
+          this->database.insert();
         }
         catch ( const std::exception &e ) {
           message.str(""); message << "ERROR adding keys to database: " << e.what();

--- a/sequencerd/sequencer_interface.cpp
+++ b/sequencerd/sequencer_interface.cpp
@@ -169,7 +169,8 @@ namespace Sequencer {
       logwrite( function, message.str() );
 #endif
       try {
-        database = std::make_unique<Database::Database>(db_host, db_port, db_user, db_pass);
+        // configure database object to use active targets table unless otherwise specified
+        database = std::make_unique<Database::Database>(db_host, db_port, db_user, db_pass, db_schema, db_active);
       }
       catch( const std::exception &e ) {
         logwrite( function, "ERROR: "+std::string(e.what()) );
@@ -254,6 +255,7 @@ namespace Sequencer {
         bindings = { { "setname", mysqlx::Value(setname_in) } };
       }
 
+      // read from active targets table
       mysqlx::RowResult result = database->read(this->db_sets,
                                                 this->targetset_cols,
                                                 condition,
@@ -372,7 +374,7 @@ namespace Sequencer {
                  { "POINTMODE", mysqlx::Value( pointmode_in ) }            // POINTMODE
                };
 
-      database->insert(record);
+      database->insert(record);                                            // into active targets table
     }
     catch ( const std::exception &ex ) {
       logwrite( function, "ERROR: "+std::string(ex.what()) );
@@ -405,6 +407,7 @@ namespace Sequencer {
       const std::string order("OBSERVATION_ID");
       std::map<std::string, mysqlx::Value> bindings = { { "obsid", mysqlx::Value(obsid) } };
 
+      // read from active targets table
       mysqlx::RowResult result = database->read(targetlist_cols,
                                                 condition,
                                                 bindings,
@@ -535,6 +538,7 @@ namespace Sequencer {
       std::map<std::string, mysqlx::Value> bindings = { { "state", mysqlx::Value(state_in) },
                                                         { "setid", mysqlx::Value(this->setid) } };
 
+      // read from active targets table
       mysqlx::RowResult result = database->read(this->targetlist_cols,
                                                 condition,
                                                 bindings,
@@ -767,6 +771,7 @@ namespace Sequencer {
       const std::string condition("OBSERVATION_ID like :obsid");
       std::map<std::string, mysqlx::Value> bindings = { { "obsid", mysqlx::Value(this->obsid) } };
 
+      // read from active targets table
       mysqlx::RowResult result = database->read(this->targetlist_cols,
                                                 condition,
                                                 bindings);
@@ -782,7 +787,7 @@ namespace Sequencer {
         return( ERROR );
       }
 
-      // update the state here
+      // update state in the active targets table
       //
       std::map<std::string, mysqlx::Value> setdata = { { "STATE", mysqlx::Value(newstate) } };
 
@@ -853,7 +858,7 @@ namespace Sequencer {
                  { "OTMFLAG",        mysqlx::Value( this->otmflag ) }        // from target table
                };
 
-      database->insert( this->db_completed, record );
+      database->insert( this->db_completed, record );                        // into completed targets table
     }
     catch ( const std::exception &e ) {
       logwrite( function, "ERROR: "+std::string(e.what()) );

--- a/sequencerd/sequencer_interface.h
+++ b/sequencerd/sequencer_interface.h
@@ -165,41 +165,6 @@ namespace Sequencer {
   /***** Sequencer::CalibrationTarget *****************************************/
 
 
-  /***** Sequencer::DatabaseManager *******************************************/
-  /**
-   * @class  DatabaseManager
-   *
-   */
-  class DatabaseManager {
-    private:
-      mysqlx::Session session;
-      mysqlx::Schema db;
-      mysqlx::Table table;
-
-    public:
-      DatabaseManager( const std::string &host, int port,
-                       const std::string &user, const std::string &password,
-                       const std::string &schema, const std::string tablename )
-        : session( mysqlx::SessionOption::HOST, host,
-                   mysqlx::SessionOption::PORT, port,
-                   mysqlx::SessionOption::USER, user,
-                   mysqlx::SessionOption::PWD, password ),
-          db( session.getSchema(schema) ),
-          table( db.getTable(tablename) ) { }
-
-      mysqlx::RowResult do_query( const std::string &condition, const std::string &order,
-                                  const std::map<std::string, std::string> &bindings,
-                                  const std::vector<std::string> &columns={"*"} ) {
-        auto query = table.select(columns).where(condition).orderBy(order);
-        for ( const auto &[key, value] : bindings ) {
-          query.bind(key, value);
-        }
-        return query.execute();
-      }
-  };
-  /***** Sequencer::DatabaseManager *******************************************/
-
-
   /***** Sequencer::TargetInfo ************************************************/
   /**
    * @class  TargetInfo
@@ -252,7 +217,7 @@ namespace Sequencer {
                                        "SET_NAME" },
                      offset_threshold(0), max_tcs_offset(0) { init_record(); }
 
-      std::unique_ptr<DatabaseManager> dbManager;
+      std::unique_ptr<Database::Database> database;
 
       SkyInfo::FPOffsets fpoffsets;       ///< for calling Python fpoffsets, defined in ~/Software/common/skyinfo.h
 

--- a/thermald/thermal_server.cpp
+++ b/thermald/thermal_server.cpp
@@ -631,10 +631,6 @@ namespace Thermal {
           timeout( 0, "sec" );
         }
 
-        // Database is destructed when it leaves scope, and the destructor
-        // will close it, but this is tidy. close can throw an exception.
-        //
-        database.close();
         logwrite( function, "telemetry database closed" );
       }
       catch ( const mysqlx::Error &err ) {

--- a/thermald/thermal_server.cpp
+++ b/thermald/thermal_server.cpp
@@ -623,9 +623,9 @@ namespace Thermal {
           server.interface.telemdata.merge( server.interface.campbell.datamap );
           server.interface.telemdata.merge( server.interface.lakeshoredata );
 
-          // write the telemdata map to the database
+          // insert the telemdata map to the database
           //
-          database.write( server.interface.telemdata );
+          database.insert( server.interface.telemdata );
 
           server.telem_sleeptimer.sleepFor( std::chrono::seconds( duration ) );
           timeout( 0, "sec" );

--- a/utils/database.cpp
+++ b/utils/database.cpp
@@ -10,6 +10,158 @@
 
 namespace Database {
 
+  /***** DatabasePool::DatabasePool *******************************************/
+  /**
+   * @brief      DatabasePool class destructor
+   * @details    connections will be automatically closed and queue emptied
+   *             when the object is destroyed
+   *
+   */
+  DatabasePool::DatabasePool(const std::string &host, int port, const std::string &user,
+                             const std::string &pass, const std::string &schema,
+                             const std::string &table, int poolsz) :
+    _dbhost(host), _dbport(port), _dbuser(user), _dbpass(pass),
+    _dbschema(schema), _dbtable(table), _poolsz(poolsz) {
+    // create the pool of sessions
+    for (int i = 0; i < _poolsz; ++i) { _db_queue.push(_create_handle()); }
+  }
+  /***** DatabasePool::DatabasePool *******************************************/
+
+
+  /***** DatabasePool::~DatabasePool ******************************************/
+  /**
+   * @brief      DatabasePool class destructor
+   * @details    connections will be automatically closed and queue emptied
+   *             when the object is destroyed
+   *
+   */
+  DatabasePool::~DatabasePool() {
+    // Don't want to re-throw anything on exception because no one will be catching
+    // it on destruction, but catch here to avoid a potential problem on destruction.
+    //
+    std::lock_guard<std::mutex> lock(_mtx);
+    while (!_db_queue.empty()) {
+      auto db = _db_queue.front();
+      _db_queue.pop();
+      try { db->session->close(); }
+      catch (...) { }
+    }
+  }
+  /***** DatabasePool::~DatabasePool ******************************************/
+
+
+  /***** DatabasePool::_create_handle *****************************************/
+  /**
+   * @brief      private function to create a single mysqlx database connection
+   * @details    Creating a session establishes a connection to the MySQL server.
+   *             The DB info comes from the class contruction.
+   *             This function will throw an exception on error.
+   * @return     shared pointer to a DatabaseHandle
+   *
+   */
+  std::shared_ptr<DatabasePool::DatabaseHandle> DatabasePool::_create_handle() {
+    auto db = std::make_shared<DatabaseHandle>();
+
+    try {
+      db->session = std::make_unique<mysqlx::Session>( mysqlx::SessionOption::HOST, _dbhost,
+                                                       mysqlx::SessionOption::PORT, _dbport,
+                                                       mysqlx::SessionOption::USER, _dbuser,
+                                                       mysqlx::SessionOption::PWD,  _dbpass );
+      db->schema  = std::make_unique<mysqlx::Schema>( *(db->session), _dbschema );
+      db->table   = std::make_unique<mysqlx::Table>( db->schema->getTable( _dbtable ) );
+    }
+    catch ( const mysqlx::Error &err ) {
+      throw mysqlx::Error( err );
+    }
+    catch ( std::exception &e ) {
+      throw std::exception( e );
+    }
+
+    return db;
+  }
+  /***** DatabasePool::_create_handle *****************************************/
+
+
+  /***** DatabasePool::borrow_handle ******************************************/
+  /**
+   * @brief      get a db handle from the pool
+   * @return     shared pointer to a DatabaseHandle
+   *
+   */
+  std::shared_ptr<DatabasePool::DatabaseHandle> DatabasePool::borrow_handle(int timeout_ms) {
+    std::unique_lock<std::mutex> lock(_mtx);
+    if (!_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] {return !_db_queue.empty(); })) {
+      throw std::runtime_error("timeout waiting for database connection");
+    }
+    auto db = _db_queue.front();
+    _db_queue.pop();
+    return db;
+  }
+  /***** DatabasePool::borrow_handle ******************************************/
+
+
+  /***** DatabasePool::return_handle ******************************************/
+  /**
+   * @brief      returns a db handle back to the pool
+   * @param[in]  db  shared pointer to a DatabaseHandle
+   *
+   */
+  void DatabasePool::return_handle(std::shared_ptr<DatabasePool::DatabaseHandle> db) {
+    {
+    std::lock_guard<std::mutex> lock(_mtx);
+    _db_queue.push(db);
+    }
+    _cv.notify_one();
+  }
+  /***** DatabasePool::return_handle ******************************************/
+
+
+  /***** DatabasePool::write **************************************************/
+  /**
+   * @brief      write the supplied data to the database table
+   * @details    may throw an exception
+   * @param[in]  data  STL map containing mysqlx data indexed by DB column name
+   *
+   * This function is overloaded by a version that writes the data stored
+   * in the class.
+   *
+   */
+  void DatabasePool::write( std::map<std::string, mysqlx::Value> data ) {
+
+    HandleGuard handle(this);
+
+    auto db = handle.get();
+
+    if (data.empty()) throw std::runtime_error("no data");
+
+    // Create vectors from the supplied STL map, pre-allocating memory for them.
+    // Vectors are easily passed directly to the mysqlx API.
+    //
+    int ncols = data.size();
+    std::vector<std::string>   cols; cols.reserve( ncols );
+    std::vector<mysqlx::Value> vals; vals.reserve( ncols );
+
+    for ( const auto &dat : data ) {
+      cols.push_back( dat.first );   // database columns
+      vals.push_back( dat.second );  // value for that column
+    }
+
+    if ( cols.empty() || vals.empty() || cols.size() != vals.size() ) {
+      throw std::runtime_error( "data empty or improperly formatted" );
+    }
+
+    // Insert a row into the database table
+    //
+    try {
+      db->table->insert( cols ).values( vals ).execute();
+    }
+    catch ( const std::exception &err ) {
+      throw;
+    }
+  }
+  /***** DatabasePool::write **************************************************/
+
+
   /***** Database::get_mysql_type *********************************************/
   /**
    * @brief      gets a string representation of the type of mysqlx value
@@ -74,8 +226,9 @@ namespace Database {
    * @param[in]  info  vector of database parameters: {host,port,user,pass,schema,table}
    *
    */
-  Database::Database( std::vector<std::string> info ) {
-    this->initialize_class( info );
+  Database::Database( std::vector<std::string> info ) :
+    _dbconfigured(false), _pool(nullptr) {
+    initialize_class(info);
   }
   /***** Database::Database ***************************************************/
 
@@ -98,145 +251,86 @@ namespace Database {
                       std::string pass,
                       std::string schema,
                       std::string table ) :
-    _dbhost( host ), _dbport( port ), _dbuser( user ), _dbpass( pass ), _dbschema( schema ), _dbtable( table ) {
+    _dbhost( host ), _dbport( port ), _dbuser( user ), _dbpass( pass ), _dbschema( schema ), _dbtable( table ),
+    _dbconfigured(false), _pool(nullptr) {
 
-    _dbconnected  = false;
-    _dbconfigured = true;
-
-    _create_connection();  // may throw exception
-
-    return;
+    initialize_class();
   }
   /***** Database::Database ***************************************************/
 
 
+  Database::~Database() {
+    try {
+      if (_pool) _pool.reset();
+    }
+    catch (...) { }
+  }
+
+
   /***** Database::initialize_class *******************************************/
   /**
-   * @brief      initialize database class object
+   * @brief      initialize database class object using stored class information
+   * @details    may throw an exception on error
+   *
+   */
+  void Database::initialize_class() {
+    try {
+      if (!_dbhost.empty() && !_dbuser.empty() && !_dbpass.empty() &&
+          !_dbschema.empty() && !_dbtable.empty() && _dbport>0) {
+        _dbconfigured = true;
+        _initialize_pool();
+      }
+      else throw std::runtime_error("bad or missing database info");
+    }
+    catch( std::exception &e ) {
+      throw;
+    }
+  }
+  /***** Database::initialize_class *******************************************/
+  /**
+   * @brief      initialize database class object using supplied information
    * @details    may throw an exception on error
    * @param[in]  info  vector of database parameters: {host,port,user,pass,schema,table}
    *
    */
-  void Database::initialize_class( std::vector<std::string> info ) {
-    std::string function = "Database::Database::initialize_class";
-    _dbconfigured = false;
-    _dbconnected  = false;  // set true in _create_connection()
-
-    if ( info.size() != 6 ) {
-      logwrite( function, "ERROR constructing: bad info vector. check config file" );
-      throw std::invalid_argument( "constructing Database object: bad info vector. check config file" );
+  void Database::initialize_class(std::vector<std::string> dbinfo) {
+    if ( dbinfo.size() != 6 ) {
+      throw std::invalid_argument( "bad info vector size constructing Database object" );
     }
 
     try {
-      _dbhost   = info.at(0);
-      _dbport   = std::stoi( info.at(1) );
-      _dbuser   = info.at(2);
-      _dbpass   = info.at(3);
-      _dbschema = info.at(4);
-      _dbtable  = info.at(5);
+      _dbhost   = dbinfo.at(0);
+      _dbport   = std::stoi( dbinfo.at(1) );
+      _dbuser   = dbinfo.at(2);
+      _dbpass   = dbinfo.at(3);
+      _dbschema = dbinfo.at(4);
+      _dbtable  = dbinfo.at(5);
+
+      initialize_class();
     }
     catch( std::exception &e ) {
-      std::stringstream message;
-      message << "ERROR constructing Database object (check config file): " << e.what();
-      logwrite( function, message.str() );
-      throw std::exception( e );
+      throw;
     }
-
-    _dbconfigured = true;  // configured now
-
-    _create_connection();  // may throw exception
-
-    return;
   }
   /***** Database::initialize_class *******************************************/
 
 
-  /***** Database::_create_connection *****************************************/
+  /***** Database::initialize_pool ********************************************/
   /**
-   * @brief      private function to create a single mysqlx database connection
-   * @details    The DB info comes from the class contruction.
-   *             This function will throw an exception on error.
+   * @brief      initialize database pool
+   * @details    may throw an exception on error
    *
    */
-  void Database::_create_connection() {
-    std::string function = "Database::Database::_create_connection";
-    std::stringstream message;
+  void Database::_initialize_pool() {
+    std::string function = "Database::Database::_initialize_pool";
 
-    try {
-      _session = std::make_unique<mysqlx::Session> ( mysqlx::SessionOption::HOST,   _dbhost,
-                                                     mysqlx::SessionOption::PORT,   _dbport,
-                                                     mysqlx::SessionOption::USER,   _dbuser,
-                                                     mysqlx::SessionOption::PWD,    _dbpass );
+    if (!_dbconfigured) throw std::runtime_error("database not configured");
 
-      _sessionopen = true;
-
-      _schema  = std::make_unique<mysqlx::Schema>( *_session, _dbschema );
-      _table   = std::make_unique<mysqlx::Table>( _schema->getTable( _dbtable ) );
-
-    }
-    catch ( const mysqlx::Error &err ) {
-      message << "ERROR: " << err;
-      logwrite( function, message.str() );
-      throw mysqlx::Error( err );
-    }
-    catch ( std::exception &e ) {
-      message << "ERROR: " << e.what();
-      logwrite( function, message.str() );
-      throw std::exception( e );
-    }
-
-    _dbconnected = true;
-
-    return;
+    // create a pool which will own all DB connections
+    _pool = std::make_unique<DatabasePool>(_dbhost, _dbport, _dbuser, _dbpass, _dbschema, _dbtable,
+                                           DBPOOLSIZE);
   }
-  /***** Database::_create_connection *****************************************/
-
-
-  /***** Database::close ******************************************************/
-  /**
-   * @brief      close a database connection
-   * @brief      may throw an exception
-   *
-   */
-  void Database::close() {
-    std::string function = "Database::Database::close";
-    std::stringstream message;
-
-    try {
-      if ( _sessionopen ) _session->close();
-      _sessionopen = false;
-
-      _table.reset();
-      _schema.reset();
-      _session.reset();
-
-      _dbconnected = false;
-    }
-    catch ( const mysqlx::Error &err ) {
-      message.str(""); message << "ERROR from mySQL: " << err;
-      logwrite( function, message.str() );
-      throw std::runtime_error("closing database: " + std::string(err.what()));
-    }
-
-    return;
-  }
-  /***** Database::close ******************************************************/
-
-
-  /***** Database::~Database **************************************************/
-  /**
-   * @brief      Database class destructor
-   * @details    connection will be automatically closed when the object is destroyed
-   *
-   */
-  Database::~Database() {
-    // Don't want to re-throw anything on exception because no one will be catching
-    // it on destruction, but catch here to avoid a potential problem on destruction.
-    //
-    try { if ( _sessionopen ) _session->close(); }
-    catch ( const mysqlx::Error &err ) { }
-  }
-  /***** Database::~Database **************************************************/
+  /***** Database::initialize_pool ********************************************/
 
 
   /***** Database::write ******************************************************/
@@ -253,54 +347,13 @@ namespace Database {
     std::string function = "Database::Database::write";
     std::stringstream message;
 
-    if ( ! _dbconnected || ! _session || ! _sessionopen ) {
-      logwrite( function, "ERROR not connected to database or session not open" );
-      throw std::runtime_error( "not connected to database or session not open" );
-    }
-
-    if ( ! _table || ! _schema ) {
-      logwrite( function, "ERROR table or schema not initialized" );
-      throw std::runtime_error( "table or schema not initialized" );
-    }
-
-    // Create vectors from the supplied STL map, pre-allocating memory for them.
-    // Vectors are easily passed directly to the mysqlx API.
-    //
-    int ncols = data.size();
-    std::vector<std::string>   cols; cols.reserve( ncols );
-    std::vector<mysqlx::Value> vals; vals.reserve( ncols );
-
-    for ( const auto &dat : data ) {
-      cols.push_back( dat.first );   // database columns
-      vals.push_back( dat.second );  // value for that column
-    }
-
-    if ( cols.empty() || vals.empty() || cols.size() != vals.size() ) {
-      logwrite( function, "ERROR data empty or improperly formatted" );
-      throw std::runtime_error( "data empty or improperly formatted" );
-    }
-
-    // Insert a row into the database table
-    //
     try {
-      _table->insert( cols ).values( vals ).execute();
+      if (!_pool) throw std::runtime_error("not connected to database");
+      _pool->write(data);
     }
-    catch ( const mysqlx::Error &err ) {
-      message.str(""); message << "ERROR from mySQL: " << err.what();
-      logwrite( function, message.str() );
-      throw;
+    catch (const std::exception &e) {
+      logwrite(function, "ERROR writing data: "+std::string(e.what()));
     }
-    catch ( const std::exception &err ) {
-      message.str(""); message << "ERROR: " << err.what();
-      logwrite( function, message.str() );
-      throw;
-    }
-    catch ( ... ) {
-      logwrite( function, "ERROR unknown exception" );
-      throw;
-    }
-
-    return;
   }
   /***** Database::write ******************************************************/
 

--- a/utils/database.cpp
+++ b/utils/database.cpp
@@ -143,7 +143,7 @@ namespace Database {
     // Create vectors from the supplied STL map, pre-allocating memory for them.
     // Vectors are easily passed directly to the mysqlx API.
     //
-    int ncols = data.size();
+    size_t ncols = data.size();
     std::vector<std::string>   cols; cols.reserve( ncols );
     std::vector<mysqlx::Value> vals; vals.reserve( ncols );
 

--- a/utils/database.cpp
+++ b/utils/database.cpp
@@ -10,140 +10,135 @@
 
 namespace Database {
 
-  /***** DatabasePool::DatabasePool *******************************************/
+  /***** SessionPool::SessionPool *********************************************/
   /**
-   * @brief      DatabasePool class constructor
+   * @brief      SessionPool class constructor
    * @details    creates a pool (queue) of connected database sessions on construction
    *
    */
-  DatabasePool::DatabasePool(const std::string &host, int port, const std::string &user,
-                             const std::string &pass, const std::string &schema,
-                             const std::string &table, int poolsz) :
-    _dbhost(host), _dbport(port), _dbuser(user), _dbpass(pass),
-    _dbschema(schema), _dbtable(table), _poolsz(poolsz) {
+  SessionPool::SessionPool(const std::string &host, int port, const std::string &user, const std::string &pass):
+    _dbhost(host), _dbport(port), _dbuser(user), _dbpass(pass) {
     // create the pool of sessions
-    for (int i = 0; i < _poolsz; ++i) { _db_queue.push(_create_handle()); }
+    for (int i = 0; i < DBPOOLSIZE; ++i) { _queue.push(_create_session()); }
   }
-  /***** DatabasePool::DatabasePool *******************************************/
+  /***** SessionPool::SessionPool *********************************************/
 
 
-  /***** DatabasePool::~DatabasePool ******************************************/
+  /***** SessionPool::~SessionPool ********************************************/
   /**
-   * @brief      DatabasePool class destructor
+   * @brief      SessionPool class destructor
    * @details    connections will be automatically closed and queue emptied
    *             when the object is destroyed
    *
    */
-  DatabasePool::~DatabasePool() {
+  SessionPool::~SessionPool() {
     // Don't want to re-throw anything on exception because no one will be catching
     // it on destruction, but catch here to avoid a potential problem on destruction.
     //
     std::lock_guard<std::mutex> lock(_mtx);
-    while (!_db_queue.empty()) {
-      auto db = _db_queue.front();
-      _db_queue.pop();
-      try { db->session->close(); }
+    while (!_queue.empty()) {
+      auto db = _queue.front();
+      _queue.pop();
+      try { db->close(); }
       catch (...) { }
     }
   }
-  /***** DatabasePool::~DatabasePool ******************************************/
+  /***** SessionPool::~SessionPool ********************************************/
 
 
-  /***** DatabasePool::_create_handle *****************************************/
+  /***** SessionPool::_create_session *****************************************/
   /**
    * @brief      private function to create a single mysqlx database connection
    * @details    Creating a session establishes a connection to the MySQL server.
    *             The DB info comes from the class contruction.
-   *             This function will throw an exception on error.
-   * @return     shared pointer to a DatabaseHandle
+   * @return     shared pointer to a mysqlx::Session
    *
    */
-  std::shared_ptr<DatabasePool::DatabaseHandle> DatabasePool::_create_handle() {
-    auto db = std::make_shared<DatabaseHandle>();
-
-    db->session = std::make_unique<mysqlx::Session>( mysqlx::SessionOption::HOST, _dbhost,
-                                                     mysqlx::SessionOption::PORT, _dbport,
-                                                     mysqlx::SessionOption::USER, _dbuser,
-                                                     mysqlx::SessionOption::PWD,  _dbpass );
-    db->schema  = std::make_unique<mysqlx::Schema>( *(db->session), _dbschema );
-    db->table   = std::make_unique<mysqlx::Table>( db->schema->getTable( _dbtable ) );
-
-    return db;
+  std::shared_ptr<mysqlx::Session> SessionPool::_create_session() {
+    try {
+      return std::make_shared<mysqlx::Session>(mysqlx::SessionOption::HOST, _dbhost,
+                                               mysqlx::SessionOption::PORT, _dbport,
+                                               mysqlx::SessionOption::USER, _dbuser,
+                                               mysqlx::SessionOption::PWD,  _dbpass);
+    }
+    catch (const mysqlx::Error& err) {
+      return nullptr;
+    }
   }
-  /***** DatabasePool::_create_handle *****************************************/
+  /***** SessionPool::_create_session *****************************************/
 
 
-  /***** DatabasePool::_test_connection ***************************************/
+  /***** SessionPool::_test_session *******************************************/
   /**
    * @brief      tests db connection using a simple table query
    * @paramm[in] db  database handle
    * @return     true|false
    *
    */
-  bool DatabasePool::_test_connection(std::shared_ptr<DatabasePool::DatabaseHandle> db) {
+  bool SessionPool::_test_session(std::shared_ptr<mysqlx::Session> db) {
     // pass-fail
     try {
-      db->session->sql("SELECT 1").execute();
+      db->sql("SELECT 1").execute();
       return true;                             // it either works,
     }
     catch (...) { return false; }              // or it doesn't.
   }
-  /***** DatabasePool::_test_connection ***************************************/
+  /***** SessionPool::_test_session *******************************************/
 
 
-  /***** DatabasePool::_borrow_handle *****************************************/
+  /***** SessionPool::_borrow_session *****************************************/
   /**
-   * @brief      get a db handle from the pool
+   * @brief      get a db session from the pool
    * @details    Database connections are always tested before given out, and
    *             if bad/stale then a new one is opened.
-   * @return     shared pointer to a DatabaseHandle
+   * @return     shared pointer to a mysqlx::Session
    *
    */
-  std::shared_ptr<DatabasePool::DatabaseHandle> DatabasePool::_borrow_handle(int timeout_ms) {
+  std::shared_ptr<mysqlx::Session> SessionPool::_borrow_session(int timeout_ms) {
     std::unique_lock<std::mutex> lock(_mtx);
-    if (!_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] {return !_db_queue.empty(); })) {
+    if (!_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] {return !_queue.empty(); })) {
       throw std::runtime_error("timeout waiting for database connection");
     }
-    auto db = _db_queue.front();
-    _db_queue.pop();
+    auto db = _queue.front();
+    _queue.pop();
 
-    // make a new handle if this one is bad
-    if (!_test_connection(db)) db = _create_handle();
+    // make a new session if this one is bad
+    if (!_test_session(db)) db = _create_session();
 
     return db;
   }
-  /***** DatabasePool::_borrow_handle *****************************************/
+  /***** SessionPool::_borrow_session *****************************************/
 
 
-  /***** DatabasePool::_return_handle *****************************************/
+  /***** SessionPool::_return_session *****************************************/
   /**
-   * @brief      returns a db handle back to the pool
-   * @param[in]  db  shared pointer to a DatabaseHandle
+   * @brief      returns a db session back to the pool
+   * @param[in]  db  shared pointer to a mysqlx::Session
    *
    */
-  void DatabasePool::_return_handle(std::shared_ptr<DatabasePool::DatabaseHandle> db) {
+  void SessionPool::_return_session(std::shared_ptr<mysqlx::Session> db) {
     {
     std::lock_guard<std::mutex> lock(_mtx);
-    _db_queue.push(db);
+    _queue.push(db);
     }
     _cv.notify_one();
   }
-  /***** DatabasePool::_return_handle *****************************************/
+  /***** SessionPool::_return_session *****************************************/
 
 
-  /***** DatabasePool::write **************************************************/
+  /***** SessionPool::write ***************************************************/
   /**
-   * @brief      write the supplied data to the database table
-   * @details    may throw an exception
-   * @param[in]  data  STL map containing mysqlx data indexed by DB column name
+   * @brief      write to the database
+   * @param[in]  schemaname database schema name
+   * @param[in]  tablename  database table name
+   * @param[in]  data       reference to map of column/value data
    *
-   * This function is overloaded by a version that writes the data stored
-   * in the class.
+   * This can throw an exception.
    *
    */
-  void DatabasePool::write( std::map<std::string, mysqlx::Value> data ) {
+  void SessionPool::write(const std::string &schemaname, const std::string &tablename, const std::map<std::string, mysqlx::Value> &data) {
 
-    if (data.empty()) throw std::runtime_error("no data");
+    if ( data.empty() ) throw std::runtime_error("no data");
 
     // Create vectors from the supplied STL map, pre-allocating memory for them.
     // Vectors are easily passed directly to the mysqlx API.
@@ -164,17 +159,68 @@ namespace Database {
     // Insert a row into the database table
     //
     try {
-      // safely get a DB handle from the pool
-      HandleGuard handle(this);
-      auto db = handle.get();
+      // safely get a DB session from the pool
+      SessionGuard session(this);
+      auto db = session.get();
 
-      db->table->insert( cols ).values( vals ).execute();
+      auto schema = std::make_unique<mysqlx::Schema>( *(db), schemaname );
+      auto table  = std::make_unique<mysqlx::Table>( schema->getTable( tablename ) );
+
+      table->insert( cols ).values( vals ).execute();
     }
     catch ( const std::exception &err ) {
       throw;
     }
   }
-  /***** DatabasePool::write **************************************************/
+  /***** SessionPool::write ***************************************************/
+
+
+  /***** SessionPool::read ****************************************************/
+  /**
+   * @brief      read from the database
+   * @param[in]  schemaname
+   * @param[in]  tablename
+   * @param[in]  columns
+   * @param[in]  where_clause
+   * @param[in]  bind_params
+   * @param[in]  order_by
+   * @param[in]  limit
+   * @param[in]  offset
+   * @return     mysqlx::RowResult
+   *
+   * This can throw an exception.
+   *
+   */
+  mysqlx::RowResult SessionPool::read(const std::string &schemaname, const std::string &tablename,
+                                      const std::vector<std::string> &columns,
+                                      const std::string &where_clause,
+                                      const std::map<std::string, mysqlx::Value> &bind_params,
+                                      const std::string &order_by,
+                                      std::optional<int> limit,
+                                      std::optional<int> offset) {
+    try {
+      // safely get a DB session from the pool
+      SessionGuard session(this);
+      auto db = session.get();
+
+      auto schema = std::make_unique<mysqlx::Schema>( *(db), schemaname );
+      auto table  = std::make_unique<mysqlx::Table>( schema->getTable( tablename ) );
+
+      mysqlx::TableSelect select = table->select(columns);
+
+      if ( !where_clause.empty() ) select = select.where(where_clause);
+      if ( !order_by.empty() )     select = select.orderBy(order_by);
+
+      for (const auto& [key, val] : bind_params) select.bind(key, val);
+
+      if (limit)  select = select.limit(*limit);
+      if (offset) select = select.offset(*offset);
+
+      return select.execute();
+    }
+    catch (const std::exception &e) { throw; }
+  }
+  /***** SessionPool::read ****************************************************/
 
 
   /***** Database::get_mysql_type *********************************************/
@@ -290,12 +336,11 @@ namespace Database {
    */
   void Database::initialize_class() {
     try {
-      if (!_dbhost.empty() && !_dbuser.empty() && !_dbpass.empty() &&
-          !_dbschema.empty() && !_dbtable.empty() && _dbport>0) {
+      if (!_dbhost.empty() && !_dbuser.empty() && !_dbpass.empty() && _dbport>0) {
         _dbconfigured = true;
         _initialize_pool();
       }
-      else throw std::runtime_error("bad or missing database info (check config file)");
+      else throw std::runtime_error("bad or missing database info");
     }
     catch( const std::exception &e ) {
       throw;
@@ -309,18 +354,21 @@ namespace Database {
    *
    */
   void Database::initialize_class(std::vector<std::string> dbinfo) {
-    if ( dbinfo.size() != 6 ) {
-      throw std::invalid_argument( "bad info vector size constructing Database object (check config file)" );
-    }
-
     try {
-      _dbhost   = dbinfo.at(0);
-      _dbport   = std::stoi( dbinfo.at(1) );
-      _dbuser   = dbinfo.at(2);
-      _dbpass   = dbinfo.at(3);
-      _dbschema = dbinfo.at(4);
-      _dbtable  = dbinfo.at(5);
-
+      switch ( dbinfo.size() ) {
+        case 6:
+          _dbtable  = dbinfo.at(5);  // optional at construction
+        case 5:
+          _dbschema = dbinfo.at(4);  // optional at construction
+        case 4:
+          _dbpass   = dbinfo.at(3);
+          _dbuser   = dbinfo.at(2);
+          _dbport   = std::stoi( dbinfo.at(1) );
+          _dbhost   = dbinfo.at(0);
+          break;
+        default:
+          throw std::invalid_argument( "bad info vector size constructing Database object" );
+      }
       initialize_class();
     }
     catch( const std::exception &e ) {
@@ -340,32 +388,112 @@ namespace Database {
     if (!_dbconfigured) throw std::runtime_error("database not configured");
 
     // create a pool which will own all DB connections
-    _pool = std::make_unique<DatabasePool>(_dbhost, _dbport, _dbuser, _dbpass, _dbschema, _dbtable,
-                                           DBPOOLSIZE);
+    _pool = std::make_unique<SessionPool>(_dbhost, _dbport, _dbuser, _dbpass);
   }
   /***** Database::initialize_pool ********************************************/
+
+
+  /***** SessionPool::read ****************************************************/
+  /**
+   * @brief      read from the database
+   * @details    may throw an exception
+   * @param[in]  schemaname     optional
+   * @param[in]  tablename      optional
+   * @param[in]  columns
+   * @param[in]  where_clause
+   * @param[in]  bind_params
+   * @param[in]  order_by
+   * @param[in]  limit
+   * @param[in]  offset
+   * @return     mysqlx::RowResult
+   *
+   */
+  mysqlx::RowResult Database::read(const std::vector<std::string> &columns,
+                                   const std::string &where_clause,
+                                   const std::map<std::string, mysqlx::Value> &bind_params,
+                                   const std::string &order_by,
+                                   std::optional<int> limit,
+                                   std::optional<int> offset) {
+    if ( _dbschema.empty() || _dbtable.empty() ) throw std::runtime_error("missing schema or table");
+    try {
+      if (!_pool) throw std::runtime_error("not connected to database");
+      return _pool->read( _dbschema, _dbtable, columns, where_clause, bind_params, order_by, limit, offset );
+    }
+    catch (const std::exception &e) {
+      logwrite("Database::Database::read", "ERROR reading: "+std::string(e.what()));
+      throw;
+    }
+  }
+  /***** SessionPool::read ****************************************************/
+  mysqlx::RowResult Database::read(const std::string &tablename,
+                                   const std::vector<std::string> &columns,
+                                   const std::string &where_clause,
+                                   const std::map<std::string, mysqlx::Value> &bind_params,
+                                   const std::string &order_by,
+                                   std::optional<int> limit,
+                                   std::optional<int> offset) {
+    if ( _dbschema.empty() ) throw std::runtime_error("missing schema");
+    try {
+      if (!_pool) throw std::runtime_error("not connected to database");
+      return _pool->read( _dbschema, tablename, columns, where_clause, bind_params, order_by, limit, offset );
+    }
+    catch (const std::exception &e) {
+      logwrite("Database::Database::read", "ERROR reading: "+std::string(e.what()));
+      throw;
+    }
+  }
+  /***** SessionPool::read ****************************************************/
+  mysqlx::RowResult Database::read(const std::string &schemaname, const std::string &tablename,
+                                   const std::vector<std::string> &columns,
+                                   const std::string &where_clause,
+                                   const std::map<std::string, mysqlx::Value> &bind_params,
+                                   const std::string &order_by,
+                                   std::optional<int> limit,
+                                   std::optional<int> offset) {
+    try {
+      if (!_pool) throw std::runtime_error("not connected to database");
+      return _pool->read( schemaname, tablename, columns, where_clause, bind_params, order_by, limit, offset );
+    }
+    catch (const std::exception &e) {
+      logwrite("Database::Database::read", "ERROR reading: "+std::string(e.what()));
+      throw;
+    }
+  }
+  /***** SessionPool::read ****************************************************/
 
 
   /***** Database::write ******************************************************/
   /**
    * @brief      write the supplied data to the indicated database table
    * @details    may throw an exception
-   * @param[in]  data  STL map containing mysqlx data indexed by DB column name
-   *
-   * This function is overloaded by a version that writes the data stored
-   * in the class.
+   * @param[in]  schemaname  schema name (optional)
+   * @param[in]  tablename   table name (optional)
+   * @param[in]  data        STL map containing mysqlx data indexed by DB column name
    *
    */
-  void Database::write( std::map<std::string, mysqlx::Value> data ) {
-    std::string function = "Database::Database::write";
-    std::stringstream message;
-
+  void Database::write(const std::map<std::string, mysqlx::Value> &data) {
+    // schema or table names must come from the class
+    if ( _dbschema.empty() || _dbtable.empty() ) throw std::runtime_error("missing schema or table");
+    write(_dbschema, _dbtable, data);
+  }
+  /***** Database::write ******************************************************/
+  void Database::write(const std::string &tablename,
+                       const std::map<std::string, mysqlx::Value> &data) {
+    // schema name must come from the class
+    if ( _dbschema.empty() ) throw std::runtime_error("missing schema");
+    write(_dbschema, tablename, data);
+  }
+  /***** Database::write ******************************************************/
+  void Database::write(const std::string &schemaname, const std::string &tablename,
+                       const std::map<std::string, mysqlx::Value> &data) {
     try {
       if (!_pool) throw std::runtime_error("not connected to database");
-      _pool->write(data);
+      _pool->write(schemaname, tablename, data);
     }
     catch (const std::exception &e) {
-      logwrite(function, "ERROR writing data: "+std::string(e.what()));
+      logwrite("Database::Database::write",
+               "ERROR writing data: "+std::string(e.what()));
+      throw;
     }
   }
   /***** Database::write ******************************************************/

--- a/utils/database.h
+++ b/utils/database.h
@@ -86,8 +86,13 @@ namespace Database {
       SessionPool(const std::string &host, int port, const std::string &user, const std::string &pass);
       ~SessionPool();
 
-      void write(const std::string &schemaname, const std::string &tablename,
-                 const std::map<std::string, mysqlx::Value> &data);
+      void insert(const std::string &schemaname, const std::string &tablename,
+                  const std::map<std::string, mysqlx::Value> &data);
+
+      void update(const std::string &schemaname, const std::string &tablename,
+                  const std::map<std::string, mysqlx::Value> &data,
+                  const std::string &condition,
+                  const std::map<std::string, mysqlx::Value> &bindings);
 
       mysqlx::RowResult read(const std::string &schemaname, const std::string &tablename,
                              const std::vector<std::string> &columns,
@@ -96,6 +101,8 @@ namespace Database {
                              const std::string &order_by = "",
                              std::optional<int> limit = std::nullopt,
                              std::optional<int> offset = std::nullopt);
+
+      std::list<std::string> get_tablenames(const std::string &schemaname);
   };
   /***** Database::SessionPool ************************************************/
 
@@ -151,6 +158,7 @@ namespace Database {
       void initialize_class();
       void initialize_class(std::vector<std::string> dbinfo);
 
+      // read() is overloaded
       mysqlx::RowResult read(const std::vector<std::string> &columns,
                              const std::string &where_clause,
                              const std::map<std::string, mysqlx::Value> &bind_params,
@@ -172,13 +180,27 @@ namespace Database {
                              std::optional<int> limit = std::nullopt,
                              std::optional<int> offset = std::nullopt);
 
-      void write();                                             ///< write class map
+      // insert() is overloaded
+      void insert();
+      void insert(const std::map<std::string, mysqlx::Value> &data);
+      void insert(const std::string &tablename,
+                  const std::map<std::string, mysqlx::Value> &data);
+      void insert(const std::string &schemaname, const std::string &tablename,
+                  const std::map<std::string, mysqlx::Value> &data);
 
-      void write(const std::map<std::string, mysqlx::Value> &data);
-      void write(const std::string &tablename,
-                 const std::map<std::string, mysqlx::Value> &data);
-      void write(const std::string &schemaname, const std::string &tablename,
-                 const std::map<std::string, mysqlx::Value> &data);
+      // update() is overloaded
+      void update(const std::map<std::string, mysqlx::Value> &data,
+                  const std::string &condition,
+                  const std::map<std::string, mysqlx::Value> &bindings);
+      void update(const std::string &schemaname, const std::string &tablename,
+                  const std::map<std::string, mysqlx::Value> &data,
+                  const std::string &condition,
+                  const std::map<std::string, mysqlx::Value> &bindings);
+
+
+      // get_tablenames() is overloaded
+      std::list<std::string> get_tablenames();
+      std::list<std::string> get_tablenames(const std::string &schemaname);
 
       /***** Database::Database::add_key_val **********************************/
       /**
@@ -231,12 +253,12 @@ namespace Database {
       /***** Database::Database::add_from_json ********************************/
 
       /**
-       * @brief      writes an STL map of any single type rather than mysqlx::Value
+       * @brief      insert an STL map of any single type rather than mysqlx::Value
        * @param[in]  data  map of data of any single type, indexed by field name
        */
       template <typename T>
-      void write( std::map<std::string, T> data ) {
-        this->write(data);
+      void insert( std::map<std::string, T> data ) {
+        this->insert(data);
       }
   };
   /***** Database::Database ***************************************************/


### PR DESCRIPTION
Adds SessionPool class, which on construction creates a pool of connected database sessions using a queue. 
Modifies the existing Database class to make use of SessionPool, retrieving/returning connections from/to the pool.
Clients don't know anything about a pool.
Adds helper functions to Database to insert, update and read database records.
Updates database clients (sequencerd, acamd, thermald) to make use of this.

This addresses Issue https://github.com/CaltechOpticalObservatories/NGPS/issues/314