### PR TITLE
adds pre-commit hook to prevent direct commits to main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  echo "ERROR: Direct commits to main branch are not allowed!"
+  echo "Please create a feature branch instead:"
+  echo "  git checkout -b feature/your-feature-name"
+  exit 1
+fi


### PR DESCRIPTION
Local commits were accidentally made to the main branch instead of a feature branch. This caused divergence when pulling updates, resulting in merge commits that couldn't be pushed due to branch protection. Resolved by moving changes to a feature branch (PR https://github.com/CaltechOpticalObservatories/NGPS/pull/349) and resetting local main to match remote.

This commit adds a "pre-commit hook" to remind developers not to commit directly to main. Note: This is a convenience check only and can be bypassed. The GitHub branch protection rules remain the primary enforcement mechanism