### PR TITLE
Bugfix/long keyword

### DIFF
--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -1570,7 +1570,7 @@ namespace Acam {
     Common::extract_telemetry_value( jmessage, "RA",         telem.ra_scope_h );
     Common::extract_telemetry_value( jmessage, "DEC",        telem.dec_scope_d );
     Common::extract_telemetry_value( jmessage, "RAOFFSET",   telem.offsetra );
-    Common::extract_telemetry_value( jmessage, "DECLOFFSET", telem.offsetdec );
+    Common::extract_telemetry_value( jmessage, "DECLOFFS",   telem.offsetdec );
     Common::extract_telemetry_value( jmessage, "AZ",         telem.az );
     Common::extract_telemetry_value( jmessage, "TELFOCUS",   telem.telfocus );
     Common::extract_telemetry_value( jmessage, "AIRMASS",    telem.airmass );

--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -3256,7 +3256,7 @@ namespace AstroCam {
           {"CASANGLE",   "", "TCS reported Cassegrain angle in deg", "FLOAT"},
           {"HA",         "", "hour angle"},
           {"RAOFFSET",   "", "offset Right Ascension"},
-          {"DECLOFFSET", "", "offset Declination"},
+          {"DECLOFFS",   "", "offset Declination"},
           {"TELRA",      "", "TCS reported Right Ascension"},
           {"TELDEC",     "", "TCS reported Declination"},
           {"AZ",         "", "TCS reported azimuth"},

--- a/common/common.h
+++ b/common/common.h
@@ -644,15 +644,24 @@ namespace Common {
       template <class T> long addkey( const std::string &key, T tval, const std::string &comment, int prec ) {
         return do_addkey( key, tval, comment, prec, "" );
       }
-      template <class T> long do_addkey( const std::string &key,
+      template <class T> long do_addkey( const std::string &keyin,
                                          T tval,
                                          const std::string &comment,
                                          int prec,
                                          std::string type_in ) {
+        const std::string function("Common::FitsKeys::do_addkey");
         std::stringstream val;
-        std::string type, value;
+        std::string key, type, value;
 
-        if ( key.empty() || ( key.find(" ") != std::string::npos ) ) return NO_ERROR;
+        if ( keyin.empty() || ( keyin.find(" ") != std::string::npos ) ) return NO_ERROR;
+
+        // truncate keywords to max allowed 8 characters
+        //
+        if (keyin.length() > 8) {
+          key = keyin.substr(0,8);
+          logwrite(function, "NOTICE: keyword '"+keyin+"' truncated to '"+key+"'");
+        }
+        else key = keyin;
 
         // this determines the type based on the templated tval
         // and formats the value if needed (for floating point precision)

--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -1134,7 +1134,7 @@ namespace Slicecam {
     Common::extract_telemetry_value( jmessage, "RA",         telem.ra_scope_h );
     Common::extract_telemetry_value( jmessage, "DEC",        telem.dec_scope_d );
     Common::extract_telemetry_value( jmessage, "RAOFFSET",   telem.offsetra );
-    Common::extract_telemetry_value( jmessage, "DECLOFFSET", telem.offsetdec );
+    Common::extract_telemetry_value( jmessage, "DECLOFFS",   telem.offsetdec );
     Common::extract_telemetry_value( jmessage, "AZ",         telem.az );
     Common::extract_telemetry_value( jmessage, "TELFOCUS",   telem.telfocus );
     Common::extract_telemetry_value( jmessage, "AIRMASS",    telem.airmass );

--- a/tcsd/tcs_interface.cpp
+++ b/tcsd/tcs_interface.cpp
@@ -51,7 +51,7 @@ namespace TCS {
     jmessage_out["CASANGLE"]   = this->tcs_info.cassangle;  // double
     jmessage_out["HA"]         = this->tcs_info.ha;         // string
     jmessage_out["RAOFFSET"]   = this->tcs_info.offsetra;   // double
-    jmessage_out["DECLOFFSET"] = this->tcs_info.offsetdec;  // double
+    jmessage_out["DECLOFFS"]   = this->tcs_info.offsetdec;  // double
     jmessage_out["TELRA"]      = this->tcs_info.ra_hms;     // string "hh:mm:ss.s"
     jmessage_out["TELDEC"]     = this->tcs_info.dec_dms;    // string "dd:mm:ss.s"
     jmessage_out["RA"]         = radec_to_decimal( this->tcs_info.ra_hms );


### PR DESCRIPTION
This renames json key `DECLOFFSET` to `DECLOFFS` because it was being used also as a FITS header keyword. Also truncate keywords to 8 chars as they are added to the keyword database.

Note that this was branched from the **hotfixes** branch.
