### PR TITLE
Support binning BOI

### DIFF
--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -4977,7 +4977,6 @@ logwrite(function, message.str());
     int dev=-1;
     std::string chan;
     bool readonly=false;
-    bool useinit=false;
     if ( this->extract_dev_chan( args, dev, chan, retstring ) != NO_ERROR ) return ERROR;
 
     // If no args beyond chan then retstring is empty so this is a read-only request
@@ -5013,17 +5012,17 @@ logwrite(function, message.str());
       return NO_ERROR;
     }
 
-    // parse the input stream
-    if (!useinit && !(iss >> spat >> spec >> osspat >> osspec >> binspat >> binspec)) {
+    // if init requested then image size comes from the class
+    if (args.find("init") != std::string::npos) {
+      this->get_logical(pcontroller, spat, spec, osspat, osspec, binspat, binspec);
+    }
+    // otherwise parse the input stream
+    else
+    if (!(iss >> spat >> spec >> osspat >> osspec >> binspat >> binspec)) {
       logwrite(function,
-        "ERROR invalid number of arguments. expected integer <spat> <spec> <osspat> <osspec> <binspat> <binspec>");
+        "ERROR invalid arguments '"+retstring+"':  expected integer <spat> <spec> <osspat> <osspec> <binspat> <binspec>");
       retstring="invalid_argument";
       return ERROR;
-    }
-    else
-    // if init requested then overwrite with values from the class
-    if (useinit) {
-      this->get_logical(pcontroller, spat, spec, osspat, osspec, binspat, binspec);
     }
 
     // Check image size

--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -852,7 +852,7 @@ namespace AstroCam {
    */
   long Interface::do_bin( std::string args, std::string &retstring ) {
     std::string function = "AstroCam::Interface::do_bin";
-    std::stringstream message;
+    std::ostringstream message;
     long error = NO_ERROR;
 
     // Help
@@ -882,12 +882,12 @@ namespace AstroCam {
     //
     if ( this->exposure_pending() ) {
       std::vector<int> pending = this->exposure_pending_list();
-      message.str(""); message << "ERROR: cannot change binning while exposure is pending for chan";
+      message << "ERROR: cannot change binning while exposure is pending for chan";
       message << ( pending.size() > 1 ? "s " : " " );
       for ( const auto &dev : pending ) message << this->controller.at(dev).channel << " ";
       this->camera.async.enqueue_and_log( "CAMERAD", function, message.str() );
       retstring="exposure_in_progress";
-      return(ERROR);
+      return ERROR;
     }
 
     // Tokenize args to get the axis and possible binning factor. There
@@ -934,40 +934,29 @@ namespace AstroCam {
           auto pcontroller = this->get_active_controller(dev);
           if (!pcontroller) continue;
 
-          // With Bands Of Interest (spatial) recompute BOI table and set image size
-          if (pcontroller->has_boi() && logical_axis=="spat") {
-            error = this->load_boi_pairs(pcontroller);
-          }
-          else {
-            // Make a local copy of the class' binning for both (physical) axes
-            //
-            int _binning[2];
-            _binning[_ROW_] = pcontroller->info.binning[_ROW_];
-            _binning[_COL_] = pcontroller->info.binning[_COL_];
-            // determine which physical axis corresponds to the requested logical axis
-            int physical_axis = logical_axis=="spec" ? pcontroller->spec_physical_axis()
-                                                     : pcontroller->spat_physical_axis();
-            // then override only the axis requested here.
-            _binning[physical_axis] = binfactor;
+          // determine which physical axis corresponds to the requested logical axis
+          int physical_axis = logical_axis=="spec" ? pcontroller->spec_physical_axis()
+                                                   : pcontroller->spat_physical_axis();
 
-            // call image_size() with logical coordinates
-            int spat, spec, osspat, osspec, binspat, binspec;
-            pcontroller->physical_to_logical(pcontroller->detrows, pcontroller->detcols,
-                                             spat, spec);
-            pcontroller->physical_to_logical(pcontroller->osrows0, pcontroller->oscols0,
-                                             osspat, osspec);
-            pcontroller->physical_to_logical(_binning[_ROW_], _binning[_COL_],
-                                             binspat, binspec);
-            message.str("");
-            message << dev     << " "
-                    << spat    << " "
-                    << spec    << " "
-                    << osspat  << " "
-                    << osspec  << " "
-                    << binspat << " "
-                    << binspec;
-            error = this->image_size( message.str(), retstring );  // this retstring only used on error
+          // update the binning factor in the info class for this axis
+          pcontroller->info.binning[physical_axis] = binfactor;
+
+          // get the logical coordinates from the class
+          int spat, spec, osspat, osspec, binspat, binspec;
+          this->get_logical(pcontroller, spat, spec, osspat, osspec, binspat, binspec);
+
+          // when requested axis is spatial and a BOI is defined,
+          // spat is sum of BOI bands and osspat is removed
+          if (logical_axis=="spat" && pcontroller->has_boi()) {
+            error = this->load_boi_pairs(pcontroller, spat);
+            osspat = 0;
           }
+
+          if (error==NO_ERROR) error = this->set_image_size(pcontroller,
+                                                            spat,    spec,
+                                                            osspat,  osspec,
+                                                            binspat, binspec);
+
           if (error != NO_ERROR) break;
         }
       }
@@ -977,20 +966,19 @@ namespace AstroCam {
         int dev = this->active_devnums[0];
         int physical_axis = (logical_axis=="spec") ? this->controller.at(dev).spec_physical_axis() :
                                                      this->controller.at(dev).spat_physical_axis();
-        message.str(""); message << this->controller.at(dev).info.binning[physical_axis];
+        message << this->controller.at(dev).info.binning[physical_axis];
         if ( error == NO_ERROR ) retstring = message.str();
       }
     }
-    catch ( std::exception &e ) {
-      message.str(""); message << "ERROR: parsing \"" << args << "\": " << e.what();
-      logwrite( function, message.str() );
+    catch (const std::exception &e) {
+      logwrite(function, "ERROR parsing '"+args+"': "+std::string(e.what()));
       retstring="invalid_argument";
-      return( ERROR );
+      return ERROR;
     }
 
     logwrite( function, message.str() );
 
-    return( error );
+    return error;
   }
   /***** AstroCam::Interface::do_bin ******************************************/
 
@@ -4061,8 +4049,23 @@ for ( const auto &dev : selectdev ) {
     //
     else
     if (!readonly) {
+      // parse the args into class interest bands vector
       error = this->parse_boi_pairs(pcontroller, args);
-      if (error==NO_ERROR) error = this->load_boi_pairs(pcontroller);
+
+      // load class interest bands vector into controller
+      int boi_spat;
+      if (error==NO_ERROR) error = this->load_boi_pairs(pcontroller, boi_spat);
+
+      // get the logical coordinates
+      int spat, spec, ospat, ospec, bspat, bspec;
+      this->get_logical(pcontroller, spat, spec, ospat, ospec, bspat, bspec);
+
+      // set the new image size, overriding spatial with boi_spat,
+      // overriding overscan spatial with 0
+      if (error==NO_ERROR) error = this->set_image_size(pcontroller,
+                                                        boi_spat, spec,
+                                                        0, ospec,
+                                                        bspat, bspec);
     }
 
     // always return the current table
@@ -4129,10 +4132,11 @@ for ( const auto &dev : selectdev ) {
    *             the controller. The BOI table in the controller is re-written and
    *             the image_size will be updated.
    * @param[in]  pcontroller  pointer to Controller object
+   * @param[out] spat_total   reference to total number of spatial lines (sum of all bands)
    * @return     ERROR|NO_ERROR
    *
    */
-  long Interface::load_boi_pairs(Controller* pcontroller) {
+  long Interface::load_boi_pairs(Controller* pcontroller, int &spat_total) {
     const std::string function = "AstroCam::Interface::load_boi_pairs";
 
     auto chan = pcontroller->channel;
@@ -4147,7 +4151,7 @@ for ( const auto &dev : selectdev ) {
     if ( this->do_native( dev, "BOI 0 0 0" ) != NO_ERROR ) return ERROR;
 
     // the total number spatial lines in the image will be the sum of all nreads of all bands
-    int spat_total = 0;
+    spat_total = 0;
 
     // loop through the class interest bands table
     // adjust nskip,nread for binning and write the adjusted values
@@ -4169,34 +4173,7 @@ for ( const auto &dev : selectdev ) {
       spat_total += adj.second;
     }
 
-    // Before updating the image size, translate the current dimensions (rows/cols)
-    // to logical (spat/spec).
-    //
-    int spec_current, spat_current;
-    pcontroller->physical_to_logical(pcontroller->detrows, pcontroller->detcols,
-                                     spat_current, spec_current);
-
-    int osspat_current, osspec_current;
-    pcontroller->physical_to_logical(pcontroller->osrows, pcontroller->oscols,
-                                     osspat_current, osspec_current);
-
-    int binspat_current, binspec_current;
-    pcontroller->physical_to_logical(pcontroller->info.binning[_ROW_], pcontroller->info.binning[_COL_],
-                                     binspat_current, binspec_current);
-
-    // Now update the image size
-    //
-    std::ostringstream cmd;
-    cmd << chan            << " "  // this channel
-        << spat_total      << " "  // new spatial dimension is sum of all bands
-        << spec_current    << " "  // don't change original spectral dimension
-        << 0               << " "  // force no spatial overscans
-        << osspec_current  << " "  // don't change original spectral overscans
-        << binspat_current << " "  // don't change spatial binning
-        << binspec_current;        // don't change spectral binning
-
-    std::string retstring;
-    return this->image_size( cmd.str(), retstring );
+    return NO_ERROR;
   }
   /***** AstroCam::Interface::load_boi_pairs **********************************/
 
@@ -4940,7 +4917,6 @@ logwrite(function, message.str());
       retstring.append( "  Camera controller connection must first be open.\n" );
       retstring.append( "  If no args are supplied then the current parameters for dev|chan are returned.\n" );
       retstring.append( "  Specify <chan> from { " );
-      message.str("");
       for ( const auto &con : this->controller ) {
         // skip unconfigured and inactive controllers
         if (!con.second.configured || !con.second.active) continue;
@@ -5025,12 +5001,53 @@ logwrite(function, message.str());
 
     // Check image size
     if ( spat<1 || spec<1 || osspat<0 || osspec<0 || binspat<1 || binspec<1 ) {
-      message.str(""); message << "ERROR invalid image size " << spat << " " << spec << " "
-                               << osspat << " " << osspec << " " << binspat << " " << binspec;
+      message << "ERROR invalid image size " << spat << " " << spec << " "
+              << osspat << " " << osspec << " " << binspat << " " << binspec;
       logwrite( function, message.str() );
       retstring="invalid_argument";
       return ERROR;
     }
+
+    // set image size
+    //
+    long error = this->set_image_size(pcontroller, spat, spec, osspat, osspec, binspat, binspec);
+
+    // Return the physical values stored in the class as logical (spat/spec)
+    //
+    this->get_logical(pcontroller, spat, spec, osspat, osspec, binspat, binspec);
+    message << "spat spec osspat osspec binspat binspec = ";
+    message << spat << " " << spec << " " << osspat << " " << osspec << " " << binspat << " " << binspec
+            << ( pcontroller->connected ? "" : " [inactive]" );
+    logwrite( function, message.str() );
+    retstring = message.str();
+    return error;
+  }
+  /***** AstroCam::Interface::image_size **************************************/
+
+
+  /***** AstroCam::Interface::set_image_size **********************************/
+  /**
+   * @brief      set image size parameters and allocate PCI memory
+   * @details    Sets ROWS COLS OSROWS OSCOLS BINROWS BINCOLS for a
+   *             given device|channel. This calls geometry() and buffer() to
+   *             set the image geometry on the controller and allocate a PCI buffer.
+   *             For internal use.
+   * @param[in]  pcontroller  pointer to Controller object
+   * @param[in]  spat         spatial pixel dimension
+   * @param[in]  spec         spectral pixel dimension
+   * @param[in]  osspat       spatial overscans
+   * @param[in]  osspec       spectral overscans
+   * @param[in]  binspat      spatial binning factor
+   * @param[in]  binspec      spectral binning factor
+   * @return     ERROR | NO_ERROR
+   *
+   */
+  long Interface::set_image_size(Controller* pcontroller,
+                                 int spat,    int spec,
+                                 int osspat,  int osspec,
+                                 int binspat, int binspec) {
+    const std::string function("AstroCam::Interface::set_image_size");
+    std::ostringstream message;
 
     // If binned by a non-evenly-divisible factor then skip modulo that
     // many at the start. These will be removed from the image.
@@ -5114,9 +5131,9 @@ logwrite(function, message.str());
     // the PCI buffer with buffer().
     //
     if ( pcontroller->info.set_axes() != NO_ERROR ) {
-      message.str(""); message << "ERROR setting axes for device " << dev;
+      message << "ERROR setting axes for chan " << pcontroller->channel;
       this->camera.async.enqueue_and_log( "CAMERAD", function, message.str() );
-      return( ERROR );
+      return ERROR;
     }
 
     // because set_axes() doesn't scale overscan
@@ -5139,7 +5156,7 @@ logwrite(function, message.str());
       //
       std::stringstream geostring;
       std::string retstring;
-      geostring << dev << " "
+      geostring << pcontroller->devnum << " "
                 << pcontroller->info.axes[_ROW_] << " "
                 << pcontroller->info.axes[_COL_];
 
@@ -5149,8 +5166,8 @@ logwrite(function, message.str());
 //    logwrite( function, message.str() );
 
       if ( this->buffer( geostring.str(), retstring ) != NO_ERROR ) {
-        message.str(""); message << "ERROR: allocating buffer for chan " << pcontroller->channel
-                                 << " " << pcontroller->devname;
+        message << "ERROR allocating buffer for chan " << pcontroller->channel
+                << " " << pcontroller->devname;
         logwrite( function, message.str() );
         return ERROR;
       }
@@ -5159,7 +5176,7 @@ logwrite(function, message.str());
 //    logwrite(function, message.str());
 
       if ( this->do_geometry( geostring.str(), retstring ) != NO_ERROR ) {
-        message.str(""); message << "ERROR: setting geometry for chan " << pcontroller->channel;
+        message << "ERROR setting geometry for chan " << pcontroller->channel;
         logwrite( function, message.str() );
         return ERROR;
       }
@@ -5173,39 +5190,21 @@ logwrite(function, message.str());
           << pcontroller->skiprows << " "
           << pcontroller->info.binning[_COL_] << " "
           << pcontroller->skipcols;
-      if ( this->do_native( dev, cmd.str(), retstring ) != NO_ERROR ) return ERROR;
+      if ( this->do_native( pcontroller->devnum, cmd.str(), retstring ) != NO_ERROR ) return ERROR;
 
       // finally can set this
       pcontroller->is_imsize_set = true;
     }
     else {
-      message.str(""); message << "saved but not sent to controller because chan " << pcontroller->channel
-                               << (!pcontroller->connected ? " not connected ":"")
-                               << (!pcontroller->firmwareloaded ? " firmware not loaded" :"");
+      message << "saved but not sent to controller because chan " << pcontroller->channel
+              << (!pcontroller->connected ? " not connected ":"")
+              << (!pcontroller->firmwareloaded ? " firmware not loaded" :"");
       logwrite( function, message.str() );
     }
 
-    // Return the physical values stored in the class as logical (spat/spec)
-    //
-    pcontroller->physical_to_logical( pcontroller->detrows, pcontroller->detcols, spat, spec );
-    pcontroller->physical_to_logical( pcontroller->osrows, pcontroller->oscols, osspat, osspec );
-    pcontroller->physical_to_logical( pcontroller->info.binning[_ROW_], pcontroller->info.binning[_COL_],
-                                      binspat, binspec );
-
-    message.str(""); message << "spat spec osspat osspec binspat binspec = ";
-    message << spat << " " << spec << " " << osspat << " " << osspec << " " << binspat << " " << binspec
-            << ( pcontroller->connected ? "" : " [inactive]" );
-    logwrite( function, message.str() );
-
-    retstring = message.str();
-
-    message.str(""); message << "[DEBUG] physical rows=" << pcontroller->detrows
-                             << " cols=" << pcontroller->detcols;
-    logwrite( function, message.str() );
-
-    return( NO_ERROR );
+    return NO_ERROR;
   }
-  /***** AstroCam::Interface::image_size **************************************/
+  /***** AstroCam::Interface::set_image_size **********************************/
 
 
   /***** AstroCam::Interface::do_geometry *************************************/

--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -846,6 +846,7 @@ namespace AstroCam {
     return( NO_ERROR );
   }
 
+
   /***** AstroCam::Interface::do_bin ******************************************/
   /**
    * @brief      set/get binning factor
@@ -934,40 +935,40 @@ namespace AstroCam {
           auto pcontroller = this->get_active_controller(dev);
           if (!pcontroller) continue;
 
-          // determine which physical axis corresponds to the requested logical axis
-          int physical_axis;
-          if (logical_axis == "spec") {
-            physical_axis = pcontroller->spec_physical_axis();
+          // For Bands of Interest this will recompute the BOI table and set the image size
+          if (pcontroller->has_boi() && logical_axis=="spec") {
+            error = this->load_boi_pairs(pcontroller);
           }
           else {
-            physical_axis = pcontroller->spat_physical_axis();
+            // Make a local copy of the class' binning for both (physical) axes
+            //
+            int _binning[2];
+            _binning[_ROW_] = pcontroller->info.binning[_ROW_];
+            _binning[_COL_] = pcontroller->info.binning[_COL_];
+            // determine which physical axis corresponds to the requested logical axis
+            int physical_axis = logical_axis=="spec" ? pcontroller->spec_physical_axis()
+                                                     : pcontroller->spat_physical_axis();
+            // then override only the axis requested here.
+            _binning[physical_axis] = binfactor;
+
+            // call image_size() with logical coordinates
+            int spat, spec, osspat, osspec, binspat, binspec;
+            pcontroller->physical_to_logical(pcontroller->detrows, pcontroller->detcols,
+                                             spat, spec);
+            pcontroller->physical_to_logical(pcontroller->osrows0, pcontroller->oscols0,
+                                             osspat, osspec);
+            pcontroller->physical_to_logical(_binning[_ROW_], _binning[_COL_],
+                                             binspat, binspec);
+            message.str("");
+            message << dev     << " "
+                    << spat    << " "
+                    << spec    << " "
+                    << osspat  << " "
+                    << osspec  << " "
+                    << binspat << " "
+                    << binspec;
+            error = this->image_size( message.str(), retstring );  // this retstring only used on error
           }
-
-          // Make a local copy of the class' binning for both (physical) axes
-          //
-          int _binning[2];
-          _binning[_ROW_] = pcontroller->info.binning[_ROW_];
-          _binning[_COL_] = pcontroller->info.binning[_COL_];
-          // then override only the axis requested here.
-          _binning[physical_axis] = binfactor;
-
-          // call image_size() with logical coordinates
-          int spat, spec, osspat, osspec, binspat, binspec;
-          pcontroller->physical_to_logical(pcontroller->detrows, pcontroller->detcols,
-                                           spat, spec);
-          pcontroller->physical_to_logical(pcontroller->osrows0, pcontroller->oscols0,
-                                           osspat, osspec);
-          pcontroller->physical_to_logical(_binning[_ROW_], _binning[_COL_],
-                                           binspat, binspec);
-          message.str("");
-          message << dev     << " "
-                  << spat    << " "
-                  << spec    << " "
-                  << osspat  << " "
-                  << osspec  << " "
-                  << binspat << " "
-                  << binspec;
-          error = this->image_size( message.str(), retstring );  // this retstring only used on error
           if (error != NO_ERROR) break;
         }
       }
@@ -1646,6 +1647,10 @@ namespace AstroCam {
    * @return     NO_ERROR on success, ERROR on error
    *
    */
+  long Interface::do_native(int dev, std::string cmdstr) {
+    std::string dontcare;
+    return this->do_native(dev, cmdstr, dontcare);
+  }
   long Interface::do_native( int dev, std::string cmdstr, std::string &retstring ) {
     std::vector<int> selectdev;
     if ( this->controller.at(dev).active ) selectdev.push_back( dev );
@@ -3966,7 +3971,7 @@ for ( const auto &dev : selectdev ) {
    *             number of rows to read. Each successive skip picks up where the
    *             last read left off. This makes use of firmware from NGPS / SWIFT
    *             commit 8080c66aeeae5aafccfd861771e5143ec114e81a
-   * @param[in]  args       string containing <chan>|<dev#> [full|<nskip1> <nread1>]
+   * @param[in]  args       string containing <chan>|<dev#> [full|<nskip1> <nread1> ... ]
    * @param[out] retstring  reference to a string for return values
    * @return     ERROR | NO_ERROR | HELP
    *
@@ -4063,7 +4068,8 @@ for ( const auto &dev : selectdev ) {
     //
     else
     if (!readonly) {
-      error = this->load_boi_pairs(pcontroller, dev, chan, args, retstring);
+      error = this->parse_boi_pairs(pcontroller, args);
+      if (error==NO_ERROR) error = this->load_boi_pairs(pcontroller);
     }
 
     // always return the current table
@@ -4075,23 +4081,15 @@ for ( const auto &dev : selectdev ) {
   /***** AstroCam::Interface::band_of_interest ********************************/
 
 
-  /***** AstroCam::Interface::load_boi_pairs **********************************/
+  /***** AstroCam::Interface::parse_boi_pairs *********************************/
   /**
-   * @brief      parses the args for nskip,nread pairs and loads them into the controller
+   * @brief      parses the args for nskip,nread pairs and stores them in the class
    * @param[in]  pcontroller  pointer to Controller object
-   * @param[in]  dev          dev number
-   * @param[in]  chan         channel for this dev
-   * @param[in]  args         input args list
-   * @param[out] retstring    return string
+   * @param[in]  args         expected: <chan>|<dev#> [full|<nskip1> <nread1> ... ]
    *
    */
-  long Interface::load_boi_pairs(Controller* pcontroller,
-                                 int dev,
-                                 const std::string &chan,
-                                 const std::string &args,
-                                 std::string &retstring) {
-    const std::string function = "AstroCam::Interface::load_boi_pairs";
-    std::ostringstream message;
+  long Interface::parse_boi_pairs(Controller* pcontroller, const std::string &args) {
+    const std::string function = "AstroCam::Interface::parse_boi_pairs";
 
     std::istringstream iss(args);
     std::vector<std::pair<int,int>> boi_table;
@@ -4099,17 +4097,16 @@ for ( const auto &dev : selectdev ) {
     std::string dummy;
     iss >> dummy;       // skip the first token which is chan|dev
 
-    // loop through args string, validating and creating a boi_table
+    // loop through args string, validating and creating a vector of the BOI table
+    // expecting pairs: nskip nread
     //
     while (iss >> nskip >> nread) {
       if (nread <= 0) {
         logwrite(function, "ERROR nread must be greater than 0");
-        retstring="invalid_argument";
         return ERROR;
       }
       if (nskip < 0) {
         logwrite(function, "ERROR nskip cannot be negative");
-        retstring="invalid_argument";
         return ERROR;
       }
       boi_table.emplace_back(nskip, nread);
@@ -4120,37 +4117,58 @@ for ( const auto &dev : selectdev ) {
     // non-int or odd number of values leaves the input stream before EOF
     if (!iss.eof() || boi_table.empty()) {
       logwrite( function, "ERROR expected pairs of integer values <nskip> <nread>" );
-      retstring="invalid_argument";
+      return ERROR;
+    }
+
+    // overwrite class vector on success
+    pcontroller->info.interest_bands = boi_table;
+
+    return NO_ERROR;
+  }
+  /***** AstroCam::Interface::parse_boi_pairs *********************************/
+
+
+  /***** AstroCam::Interface::load_boi_pairs **********************************/
+  /**
+   * @brief      loads the interest_bands table into the controller, applying binning
+   * @param[in]  pcontroller  pointer to Controller object
+   *
+   */
+  long Interface::load_boi_pairs(Controller* pcontroller) {
+    const std::string function = "AstroCam::Interface::load_boi_pairs";
+
+    auto chan = pcontroller->channel;
+    auto dev  = pcontroller->devnum;
+
+    if (!pcontroller->has_boi()) {
+      logwrite(function, "ERROR chan "+chan+" BOI table empty");
       return ERROR;
     }
 
     // initialize BOI table in controller firmware
-    if ( this->do_native( dev, "BOI 0 0 0", retstring ) != NO_ERROR ) return ERROR;
+    if ( this->do_native( dev, "BOI 0 0 0" ) != NO_ERROR ) return ERROR;
 
-    // and clear the class table
-    pcontroller->info.interest_bands.clear();
-
-    // the total number spatial lines in the image will be the sum of all the nreads
+    // the total number spatial lines in the image will be the sum of all nreads of all bands
     int spat_total = 0;
 
-    // send the BOI table to the controller firmware, one pair at a time
-    //
-    for (const auto &[nskipval, nreadval] : boi_table) {
+    // loop through the class interest bands table
+    // adjust nskip,nread for binning and write the adjusted values
+    for (const auto &[nskip, nread] : pcontroller->info.interest_bands) {
+      std::pair<int,int> adj;
+      if (adjust_boi_for_binning(pcontroller, nskip, nread, adj)==ERROR) {
+        logwrite( function, "ERROR BOI too small for current binning");
+        return ERROR;
+      }
+
       // Load this interest band into a table on the controller.
       // Firmware requires a non-zero 3rd arg here.
-      //
       std::ostringstream cmd;
-      cmd << "BOI " << nskipval << " " << nreadval << " " << 0xFFFF;
-      if ( this->do_native( dev, cmd.str(), retstring ) != NO_ERROR ) return ERROR;
+      cmd << "BOI " << adj.first << " " << adj.second << " " << 0xFFFF;
+      if ( this->do_native( dev, cmd.str() ) != NO_ERROR ) return ERROR;
       logwrite(function, "chan "+chan+": "+cmd.str());
 
-      // add this spatial line to the interest_bands table for this controller
-      //
-      pcontroller->info.interest_bands.emplace_back( nskipval, nreadval );
-
       // running summation of spatial lines of each band in the table
-      //
-      spat_total += nreadval;
+      spat_total += adj.second;
     }
 
     // Before updating the image size, translate the current dimensions (rows/cols)
@@ -4178,11 +4196,47 @@ for ( const auto &dev : selectdev ) {
         << osspec_current  << " "  // don't change original spectral overscans
         << binspat_current << " "  // don't change spatial binning
         << binspec_current;        // don't change spectral binning
-    if ( this->image_size( cmd.str(), retstring ) != NO_ERROR ) return ERROR;
 
-    return NO_ERROR;
+    std::string retstring;
+    return this->image_size( cmd.str(), retstring );
   }
   /***** AstroCam::Interface::load_boi_pairs **********************************/
+
+
+  /***** AstroCam::Interface::adjust_boi_for_binning **************************/
+  /**
+   * @brief      applies binning factor to BOI table in controller
+   * @details    BOI table is in unbinned units. This applies current binning
+   *             factor to ensure band contains an integral number of pixels and
+   *             ends on the requested unbinned pixel. The band is shortened by
+   *             the number of pixels to make it evenly divisible, which are added
+   *             into the skip portion.
+   * @param[in]  pcontroller   pointer to Controller object
+   * @param[in]  nskip         unbinned number to skip
+   * @param[in]  nread         unbinned number to read
+   * @param[out] <nskip,nread> pair adjusted for binning
+   * @return     ERROR|NO_ERROR
+   *
+   */
+  long Interface::adjust_boi_for_binning(Controller* pcontroller,
+                                         int nskip,
+                                         int nread,
+                                         std::pair<int,int> &adj) {
+    const std::string function = "AstroCam::Interface::adjust_boi_for_binning";
+
+    // bands of interest are always in the spatial axis
+    int spat_bin = pcontroller->info.binning[pcontroller->spat_physical_axis()];
+
+    // ensure nread is evenly divisible by binfactor
+    int modulus   = nread % spat_bin;
+
+    // remove the modulus from nread and add it to nskip
+    adj.first  = nskip + modulus;
+    adj.second = nskip - modulus;
+
+    return (adj.second > 0 ? NO_ERROR : ERROR);
+  }
+  /***** AstroCam::Interface::adjust_boi_for_binning **************************/
 
 
   /***** AstroCam::Interface::reset_boi_full **********************************/
@@ -4252,8 +4306,10 @@ for ( const auto &dev : selectdev ) {
     if (!pcontroller->has_boi()) return "full";
     int boinum=0;
     std::ostringstream oss;
-    for ( const auto &[nskip,nread] : pcontroller->info.interest_bands ) {
-      oss << ++boinum << ": " << nskip << " " << nread << "\n";
+    for (const auto &[nskip, nread] : pcontroller->info.interest_bands) {
+      std::pair<int,int> adj;
+      adjust_boi_for_binning(pcontroller, nskip, nread, adj);
+      oss << ++boinum << ": " << adj.first << " " << adj.second << "\n";
     }
     return oss.str();
   }

--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -935,8 +935,8 @@ namespace AstroCam {
           auto pcontroller = this->get_active_controller(dev);
           if (!pcontroller) continue;
 
-          // For Bands of Interest this will recompute the BOI table and set the image size
-          if (pcontroller->has_boi() && logical_axis=="spec") {
+          // With Bands Of Interest (spatial) recompute BOI table and set image size
+          if (pcontroller->has_boi() && logical_axis=="spat") {
             error = this->load_boi_pairs(pcontroller);
           }
           else {
@@ -4131,7 +4131,12 @@ for ( const auto &dev : selectdev ) {
   /***** AstroCam::Interface::load_boi_pairs **********************************/
   /**
    * @brief      loads the interest_bands table into the controller, applying binning
+   * @details    This reads from the Information class interest_bands vector,
+   *             adjusts the nskip,nread pairs for binning, and writes them to
+   *             the controller. The BOI table in the controller is re-written and
+   *             the image_size will be updated.
    * @param[in]  pcontroller  pointer to Controller object
+   * @return     ERROR|NO_ERROR
    *
    */
   long Interface::load_boi_pairs(Controller* pcontroller) {
@@ -4232,7 +4237,7 @@ for ( const auto &dev : selectdev ) {
 
     // remove the modulus from nread and add it to nskip
     adj.first  = nskip + modulus;
-    adj.second = nskip - modulus;
+    adj.second = nread - modulus;
 
     return (adj.second > 0 ? NO_ERROR : ERROR);
   }

--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -487,8 +487,8 @@ namespace AstroCam {
     this->controller[dev].defrows = this->controller[dev].detrows;
     this->controller[dev].defoscols = this->controller[dev].oscols;
     this->controller[dev].defosrows = this->controller[dev].osrows;
-    this->controller[dev].defbincols = this->controller[dev].info.binning[_ROW_];
-    this->controller[dev].defbinrows = this->controller[dev].info.binning[_COL_];
+    this->controller[dev].defbincols = this->controller[dev].info.binning[_COL_];
+    this->controller[dev].defbinrows = this->controller[dev].info.binning[_ROW_];
 
     return error;
   }
@@ -794,14 +794,6 @@ namespace AstroCam {
     // But now check that either the dev# is a known devnum or the tryme is a known channel.
     //
     for ( const auto &con : this->controller ) {
-#ifdef LOGLEVEL_DEBUG
-      message.str(""); message << "[DEBUG] con.first=" << con.first
-                               << " con.second.channel=" << con.second.channel
-                               << " .devnum=" << con.second.devnum
-                               << " .configured=" << (con.second.configured?"T":"F")
-                               << " .active=" << (con.second.active?"T":"F");
-      logwrite( function, message.str() );
-#endif
       if (!con.second.configured) continue;  // skip controllers not configured
       if ( con.second.channel == tryme ) {   // check to see if it matches a configured channel.
         dev  = con.second.devnum;
@@ -917,6 +909,13 @@ namespace AstroCam {
         }
       }
 
+      if ( tokens.size() > 2 ) {
+        message << "ERROR: expected <axis> [ <binfactor> ] but received \"" << retstring << "\"";
+        logwrite( function, message.str() );
+        retstring="bad_arguments";
+        return ERROR;
+      }
+
       if ( tokens.size() == 2 ) {
         binfactor = std::stoi( tokens.at(1) );
 
@@ -971,12 +970,6 @@ namespace AstroCam {
           }
           if (error != NO_ERROR) break;
         }
-      }
-      else if ( tokens.size() > 2 ) {
-        message.str(""); message << "ERROR: expected <axis> [ <binfactor> ] but received \"" << retstring << "\"";
-        logwrite( function, message.str() );
-        retstring="bad_arguments";
-        return( ERROR );
       }
 
       // return binning for the requested logical axis

--- a/camerad/astrocam.h
+++ b/camerad/astrocam.h
@@ -1001,10 +1001,12 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
           int skiprows;
           int skipcols;
 
-          int defcols;                     //!< number of detector columns (unchanged by binning)
-          int defrows;                     //!< number of detector rows (unchanged by binning)
-          int defoscols;                   //!< requested number of overscan rows
-          int defosrows;                   //!< requested number of overscan columns
+          int defcols;                     //!< default number of detector columns
+          int defrows;                     //!< default number of detector rows
+          int defoscols;                   //!< default number of overscan rows
+          int defosrows;                   //!< default number of overscan columns
+          int defbincols;                  //!< default number of overscan rows
+          int defbinrows;                  //!< default number of overscan columns
 
           std::string imsize_args;         ///< IMAGE_SIZE arguments read from config file, used to restore default
 
@@ -1032,6 +1034,7 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
 
           // Functions
           //
+          bool has_boi() const { return !info.interest_bands.empty(); }
           inline uint32_t get_bufsize() { return this->bufsize; };
           inline uint32_t set_bufsize( uint32_t sz ) { this->bufsize=sz; return this->bufsize; };
           long alloc_workbuf();
@@ -1082,6 +1085,8 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
 
       // Functions
       //
+      void get_logical(Controller* pcontroller,
+                       int &spat, int &spec, int &osspat, int &osspec, int &binspat, int &binspec);
       long camera_active_state(const std::string &args, std::string &retstring, AstroCam::ActiveState cmd);
       Controller* get_controller(const int dev);
       Controller* get_active_controller(const int dev);
@@ -1117,6 +1122,12 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
       long load_firmware(std::string &retstring);                          ///< wrapper for load_firmware
       long load_firmware(std::string timlodfile, std::string &retstring);  ///< wrapper for load_firmware
       long band_of_interest( std::string args, std::string &retstring );   ///< set/get interest bands
+      long load_boi_pairs(Controller* pcontroller, int dev,
+                          const std::string &chan, const std::string &args,
+                          std::string &retstring);
+      long reset_boi_full(Controller* pcontroller, int dev,
+                          const std::string &chan, std::string &retstring);
+      std::string print_bands_of_interest(Controller* pcontroller);
       long set_camera_mode(std::string mode);
       long exptime(std::string exptime_in, std::string &retstring);
       long do_exptime(std::string exptime_in, std::string &retstring);
@@ -1128,8 +1139,7 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
       long shutter(std::string shutter_in, std::string& shutter_out);
       long frame_transfer_mode( std::string args );
       long frame_transfer_mode( std::string args, std::string &retstring );
-      long image_size( std::string args, std::string &retstring, const bool save_as_default=false );
-      long _image_size( std::string args, std::string &retstring, const bool save_as_default=false );
+      long image_size( std::string args, std::string &retstring );
       long geometry(std::string args, std::string &retstring);
       long do_geometry(std::string args, std::string &retstring);
       long bias(std::string args, std::string &retstring);

--- a/camerad/astrocam.h
+++ b/camerad/astrocam.h
@@ -1123,7 +1123,7 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
       long load_firmware(std::string timlodfile, std::string &retstring);  ///< wrapper for load_firmware
       long band_of_interest( std::string args, std::string &retstring );   ///< set/get interest bands
       long parse_boi_pairs(Controller* pcontroller, const std::string &args);
-      long load_boi_pairs(Controller* pcontroller);
+      long load_boi_pairs(Controller* pcontroller, int &spat_total);
       long reset_boi_full(Controller* pcontroller, int dev,
                           const std::string &chan, std::string &retstring);
       long adjust_boi_for_binning(Controller* pcontroller, int nskip, int nread, std::pair<int,int> &adj);
@@ -1140,6 +1140,7 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
       long frame_transfer_mode( std::string args );
       long frame_transfer_mode( std::string args, std::string &retstring );
       long image_size( std::string args, std::string &retstring );
+      long set_image_size(Controller* pcontroller, int spat, int spec, int osspat, int osspec, int binspat, int binspec);
       long geometry(std::string args, std::string &retstring);
       long do_geometry(std::string args, std::string &retstring);
       long bias(std::string args, std::string &retstring);

--- a/camerad/astrocam.h
+++ b/camerad/astrocam.h
@@ -1122,11 +1122,11 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
       long load_firmware(std::string &retstring);                          ///< wrapper for load_firmware
       long load_firmware(std::string timlodfile, std::string &retstring);  ///< wrapper for load_firmware
       long band_of_interest( std::string args, std::string &retstring );   ///< set/get interest bands
-      long load_boi_pairs(Controller* pcontroller, int dev,
-                          const std::string &chan, const std::string &args,
-                          std::string &retstring);
+      long parse_boi_pairs(Controller* pcontroller, const std::string &args);
+      long load_boi_pairs(Controller* pcontroller);
       long reset_boi_full(Controller* pcontroller, int dev,
                           const std::string &chan, std::string &retstring);
+      long adjust_boi_for_binning(Controller* pcontroller, int nskip, int nread, std::pair<int,int> &adj);
       std::string print_bands_of_interest(Controller* pcontroller);
       long set_camera_mode(std::string mode);
       long exptime(std::string exptime_in, std::string &retstring);
@@ -1165,6 +1165,7 @@ std::vector<std::shared_ptr<Camera::Information>> fitsinfo;
       long do_native(std::vector<int> selectdev, std::string cmdstr);    ///< specified by vector
       long do_native(std::vector<int> selectdev, std::string cmdstr, std::string &retstring);  ///< specified by vector
       long do_native(int dev, std::string cmdstr, std::string &retstring);  ///< specified by devnum
+      long do_native(int dev, std::string cmdstr);  ///< specified by devnum
 
       long write_frame( int expbuf, int devnum, const std::string chan, int fpbcount );
 

--- a/camerad/camerad.cpp
+++ b/camerad/camerad.cpp
@@ -662,7 +662,7 @@ void doit(Network::TcpSocket &sock) {
                     }
     else
     if ( cmd == CAMERAD_IMSIZE ) {
-                    ret = server._image_size(args, retstring);
+                    ret = server.image_size(args, retstring);
                     }
     else
     if ( cmd == CAMERAD_READOUT ) {

--- a/camerad/generic-arc.cpp
+++ b/camerad/generic-arc.cpp
@@ -214,7 +214,4 @@ namespace AstroCam {
   }
   /***** AstroCam::Interface::native ****************8*************************/
 
-  long Interface::_image_size( std::string args, std::string &retstring, const bool save_as_default ) {
-    return this->image_size( args, retstring, save_as_default );
-  }
 }


### PR DESCRIPTION
This PR supports BOI + binning, which is implemented in PR https://github.com/CaltechOpticalObservatories/NGPS-DSP/pull/9. **Both PRs are required are are dependent upon one another.** The only DSP changes are [lines 225-256](https://github.com/CaltechOpticalObservatories/NGPS-DSP/blob/7eee60f1ab8030902e1bb286a5af61ef35134df4/DBSP-blue/tim.asm#L225-L256) which now properly accounts for binning with reading `nread` columns from the ROI table.

The changes required of camerad are much simpler than this PR makes it look. All I had to change here was to adjust the BOI table for non-integral binning. For any band that doesn't divide evenly, the modulus is removed from nread and added to nskip. This preserves the sum so that the next band starts at the expected physical pixel.

There are other changes because in doing so, it made it much simpler and easier to read to put work into their own functions.