### PR TITLE
Add acquisition automation modes and fine-tune pipeline

### DIFF
--- a/Config/sequencerd.cfg.in
+++ b/Config/sequencerd.cfg.in
@@ -107,7 +107,7 @@ CALIB_DOOR__SHUTDOWN=close
 # Virtual Slit Mode slit offset positions
 # units are arcseconds
 #
-VIRTUAL_SLITW_ACQUIRE=0.5   # slit width during acquire
+VIRTUAL_SLITW_ACQUIRE=0.4   # slit width during acquire
 VIRTUAL_SLITO_ACQUIRE=-3.0  # slit offset for acquiring target
 VIRTUAL_SLITO_EXPOSE=3.0    # slit offset for science exposure
 
@@ -155,11 +155,15 @@ TCS_PREAUTH_TIME=10                  # seconds before end of exposure to notify 
 
 # ACAM Target acquisition
 #
-ACQUIRE_TIMEOUT=90                   # seconds before ACAM acquisition sequence aborts on failure to acquire (REQUIRED!)
+ACQUIRE_TIMEOUT=120                  # seconds before ACAM acquisition sequence aborts on failure to acquire (REQUIRED!)
 ACQUIRE_RETRYS=5                     # max number of retrys before acquisition fails (optional, can be left blank to disable)
 ACQUIRE_OFFSET_THRESHOLD=0.5         # computed offset below this threshold (in arcsec) defines successful acquisition
 ACQUIRE_MIN_REPEAT=2                 # minimum number of sequential successful acquires
 ACQUIRE_TCS_MAX_OFFSET=60            # the maximum allowable offset sent to the TCS, in arcsec
+ACQ_AUTOMATIC_MODE=1                 # 1=legacy, 2=semi-auto, 3=auto
+ACQ_FINE_TUNE_CMD=ngps_acq           # command to run after guiding for final fine tune
+ACQ_FINE_TUNE_LOG=1                  # log fine tune output to /data/<datedir>/logs/ngps_acq_<datedir>.log (0/1)
+ACQ_OFFSET_SETTLE=3                  # seconds to wait after automatic offset
 
 # Calibration Settings
 # CAL_TARGET=(name caldoor calcover U G R I lampthar lampfear lampbluc lampredc lolamp hilamp mod1 mod2 ... mod6)

--- a/Config/slicecamd.cfg.in
+++ b/Config/slicecamd.cfg.in
@@ -22,6 +22,9 @@ SUB_ENDPOINT="tcp://127.0.0.1:@MESSAGE_BROKER_PUB_PORT@"
 #
 TCSD_PORT=@TCSD_BLK_PORT@
 ACAMD_PORT=@ACAMD_BLK_PORT@
+# AUTOACQ_ARGS defines defaults for slicecamd in-process ngps_acq.
+# This line intentionally includes all supported ngps_acq options.
+AUTOACQ_ARGS="--frame-mode stream --input /tmp/slicecam.fits --goal-x 150.0 --goal-y 115.5 --bg-x1 80 --bg-x2 165 --bg-y1 30 --bg-y2 210 --pixel-origin 1 --max-dist 40 --snr 3 --min-adj 4 --centroid-hw 4 --centroid-sigma 1.2 --loop 1 --cadence-sec 4 --prec-arcsec 0.4 --goal-arcsec 0.3 --gain 1.0 --dry-run 0 --tcs-set-units 0 --verbose 1 --debug 1 --use-putonslit 1 --adaptive 1 --adaptive-bright 40000 --adaptive-bright-goal 10000"
 
 # ANDOR=( <name> [emulate] <sn> <scale> <hflip> <vflip> <rot> <temp> <hbin> <vbin> )
 # For each slice camera specify:

--- a/Config/slicecamd.cfg.in
+++ b/Config/slicecamd.cfg.in
@@ -46,7 +46,7 @@ AUTOACQ_ARGS="--frame-mode stream --input /tmp/slicecam.fits --goal-x 150.0 --go
 #ANDOR=(L emulate 1002 0.06 1 1 none 0 4 4)
 #ANDOR=(R emulate 1003 0.06 1 1 none 0 4 4)
 ANDOR=(L 14223 0.06 1 1 none -60 4 4)
-ANDOR=(R 10333 0.06 0 0 none -60 4 4)  # from DBSP
+ANDOR=(R 9695 0.06 0 0 none -60 4 4)  # from DBSP
 #ANDOR=(R 13452 0.06 0 0 none -60 4 4) # s/n for ACAM
 
 # PUSH_GUI_SETTINGS=<file>

--- a/GuiderGUI/push_image.sh
+++ b/GuiderGUI/push_image.sh
@@ -96,7 +96,7 @@ if [[ "$camera" == "slicev" ]]; then
 	NAXIS2=`xpaget $id fits header 1 keyword NAXIS2`
 
 	# Camera settings
-	YCENTER=$((40/$vbin))
+	YCENTER=$((130/$vbin))
 	fontsize=$((${headsup_fontsize}-$vbin))
 	font="{$headsup_font $fontsize $headsup_fontstyle}"   ### NOT WORKING
 	echo $font
@@ -117,7 +117,7 @@ if [[ "$camera" == "slicev" ]]; then
 	echo "$reg" | xpaset $id region
 
 	# Slit/Slice labels
-  YCENTER=$(($NAXIS2 - 36/$vbin))
+  YCENTER=$(($NAXIS2 - 120/$vbin))
 	reg="image; text $xslit $YCENTER # text={TOP SLICE        SLIT=${slitw_arcsec}\"       BOTTOM SLICE   } \
 	  color=${headsup_fontcolor} width=2 $notouch font={helvetica ${headsup_fontsize} bold}"
 	echo "$reg" | xpaset $id region

--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -1453,6 +1453,11 @@ namespace Acam {
                                     this->motion.get_current_coverpos() :
                                     "not_connected" );
 
+    std::string mode = this->target.acquire_mode_string();
+    jmessage_out["ACAM_ACQUIRE_MODE"] = mode;
+    jmessage_out["ACAM_GUIDING"] = ( mode == "guiding" );
+    jmessage_out["ACAM_ACQUIRING"] = ( mode == "acquiring" );
+
     try {
       this->publisher->publish( jmessage_out );
     }
@@ -5522,12 +5527,8 @@ logwrite( function, message.str() );
     retstring = message.str();
 
     if ( this->target.acquire_mode == Acam::TARGET_GUIDE ) {
-      this->target.acquire_mode = Acam::TARGET_ACQUIRE;
-      this->target.nacquired = 0;
-      this->target.attempts = 0;
-      this->target.sequential_failures = 0;
-      this->target.timeout_time = std::chrono::steady_clock::now()
-                                + std::chrono::duration<double>(this->target.timeout);
+      // Keep GUIDE mode; just reset filtering so the new goal takes effect quickly.
+      this->target.reset_offset_params();
     }
 
     return NO_ERROR;

--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -2812,6 +2812,7 @@ namespace Acam {
         long did_acquire = iface.target.do_acquire();                 // acquire target here (if needed)
         if ( did_acquire != NO_ERROR ) {
           iface.target.acquire( Acam::TARGET_NOP );                   // disable acquire on failure
+          iface.publish_snapshot();                                    // notify ZMQ subscribers immediately
         }
         // set guide status
         iface.guide_manager.status = iface.target.acquire_mode_string();

--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -5821,8 +5821,11 @@ logwrite(function, message.str());
 
   /***** AstroCam::Interface::get_logical *************************************/
   /**
-   * @brief      return the class physical coords in logical coords
-   * @details    This is for internal use.
+   * @brief      return the original detector geometry in logical coords
+   * @details    Uses the default (config-specified) detector dimensions and
+   *             overscans so that repeated calls to set_image_size via the
+   *             bin command are idempotent. The current binning is returned
+   *             from the info class.
    * @param[in]  pcontroller pointer to Controller object
    * @param[out] spat        reference to spat
    * @param[out] spec        reference to spec
@@ -5835,8 +5838,8 @@ logwrite(function, message.str());
   void Interface::get_logical(Controller* pcontroller,
                               int &spat, int &spec, int &osspat, int &osspec, int &binspat, int &binspec) {
     if (!pcontroller) return;
-    pcontroller->physical_to_logical( pcontroller->detrows, pcontroller->detcols, spat, spec );
-    pcontroller->physical_to_logical( pcontroller->osrows, pcontroller->oscols, osspat, osspec );
+    pcontroller->physical_to_logical( pcontroller->defrows, pcontroller->defcols, spat, spec );
+    pcontroller->physical_to_logical( pcontroller->defosrows, pcontroller->defoscols, osspat, osspec );
     pcontroller->physical_to_logical( pcontroller->info.binning[_ROW_], pcontroller->info.binning[_COL_],
                                       binspat, binspec );
   }

--- a/common/common.h
+++ b/common/common.h
@@ -89,6 +89,18 @@ namespace Common {
         return ( poller.poll(100) > 0 );
       }
 
+      int get_fd() const {
+        int fd = -1;
+        _socket.get(zmqpp::socket_option::file_descriptor, fd);
+        return fd;
+      }
+
+      bool has_message_nonblock() {
+        zmqpp::poller poller;
+        poller.add(_socket, zmqpp::poller::poll_in);
+        return (poller.poll(0) > 0);  // 0ms = non-blocking
+      }
+
       /**
        * @brief       publishers bind to a socket endpoint (not for brokers)
        * @param[in]   addr   broker endpoint

--- a/common/message_keys.h
+++ b/common/message_keys.h
@@ -14,6 +14,7 @@ namespace Topic {
   inline const std::string TARGETINFO = "tcsd";
   inline const std::string SLITD      = "slitd";
   inline const std::string CAMERAD    = "camerad";
+  inline const std::string SEQ_PROGRESS = "seq_progress";
 }
 
 namespace Key {
@@ -22,5 +23,17 @@ namespace Key {
 
   namespace Camerad {
     inline const std::string READY = "ready";
+  }
+
+  namespace SeqProgress {
+    inline const std::string ONTARGET = "ontarget";
+    inline const std::string FINE_TUNE_ACTIVE = "fine_tune_active";
+    inline const std::string OFFSET_ACTIVE = "offset_active";
+    inline const std::string OFFSET_SETTLE = "offset_settle";
+    inline const std::string OFFSET_RA = "offset_ra";
+    inline const std::string OFFSET_DEC = "offset_dec";
+    inline const std::string OBSID = "obsid";
+    inline const std::string TARGET_STATE = "target_state";
+    inline const std::string EVENT = "event";
   }
 }

--- a/common/ngps_acq_embed.h
+++ b/common/ngps_acq_embed.h
@@ -1,0 +1,39 @@
+/**
+ * @file    ngps_acq_embed.h
+ * @brief   in-process API for NGPS auto-acquire logic
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ngps_acq_hooks {
+  void *user;
+
+  int (*tcs_set_native_units)( void *user, int dry_run, int verbose );
+  int (*tcs_move_arcsec)( void *user, double dra_arcsec, double ddec_arcsec,
+                          int dry_run, int verbose );
+  int (*scam_putonslit_deg)( void *user,
+                             double slit_ra_deg, double slit_dec_deg,
+                             double cross_ra_deg, double cross_dec_deg,
+                             int dry_run, int verbose );
+  int (*acam_query_state)( void *user, char *state, size_t state_sz, int verbose );
+  int (*scam_framegrab_one)( void *user, const char *outpath, int verbose );
+  int (*scam_set_exptime)( void *user, double exptime_sec, int dry_run, int verbose );
+  int (*scam_set_avgframes)( void *user, int avgframes, int dry_run, int verbose );
+  int (*is_stop_requested)( void *user );
+  void (*log_message)( void *user, const char *line );
+} ngps_acq_hooks_t;
+
+void ngps_acq_set_hooks( const ngps_acq_hooks_t *hooks );
+void ngps_acq_clear_hooks( void );
+void ngps_acq_request_stop( int stop_requested );
+int ngps_acq_run_from_argv( int argc, char **argv );
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/sequencerd_commands.h
+++ b/common/sequencerd_commands.h
@@ -8,6 +8,7 @@
 #ifndef SEQEUNCERD_COMMANDS_H
 #define SEQEUNCERD_COMMANDS_H
 const std::string SEQUENCERD_ABORT      = "abort";
+const std::string SEQUENCERD_ACQMODE    = "acqmode";
 const std::string SEQUENCERD_CONFIG     = "config";
 const std::string SEQUENCERD_DOTYPE     = "do";
 const std::string SEQUENCERD_EXIT       = "exit";
@@ -47,6 +48,7 @@ const std::vector<std::string> SEQUENCERD_SYNTAX = {
                                                      SEQUENCERD_TCS+" ...",
                                                      "",
                                                      SEQUENCERD_ABORT,
+                                                     SEQUENCERD_ACQMODE+" [ ? | <mode> ]",
                                                      SEQUENCERD_CONFIG,
                                                      SEQUENCERD_DOTYPE+" [ one | all ]",
                                                      SEQUENCERD_EXIT,

--- a/common/slicecamd_commands.h
+++ b/common/slicecamd_commands.h
@@ -10,6 +10,7 @@
 #pragma once
 
 const std::string SLICECAMD_AVGFRAMES= "avgframes"; ///< set/get camera binning
+const std::string SLICECAMD_AUTOACQ  = "autoacq";   ///< run/monitor in-process auto-acquire logic
 const std::string SLICECAMD_BIN      = "bin";       ///< set/get camera binning
 const std::string SLICECAMD_CLOSE    = "close";     ///< *** close connection to all devices
 const std::string SLICECAMD_CONFIG   = "config";    ///< reload configuration, apply what can be applied
@@ -69,6 +70,7 @@ const std::vector<std::string> SLICECAMD_SYNTAX = {
                                                 SLICECAMD_SPEED+" [ ? | <hori> <vert> ]",
                                                 SLICECAMD_TEMP+" [ ? | <setpoint> ]",
                                                 "  OTHER:",
+                                                SLICECAMD_AUTOACQ+" [ ? | start [--log-file <path>] [<args>] | stop | status ]",
                                                 SLICECAMD_PUTONSLIT+" [ ? | <slitra> <slitdec> <crossra> <crossdec> ]",
                                                 SLICECAMD_SAVEFRAMES+" [ ? | <nsave> <nskip> ]",
                                                 SLICECAMD_SHUTDOWN+" [ ? ]",

--- a/run/seq-progress
+++ b/run/seq-progress
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Launch the sequencer progress popup GUI
+#
+
+SCRIPT_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+export NGPS_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+CONFIG="${NGPS_ROOT}/Config/sequencerd.cfg"
+exec "${NGPS_ROOT}/bin/seq_progress_gui" --config "${CONFIG}" --poll-ms 10000

--- a/sequencerd/sequence.cpp
+++ b/sequencerd/sequence.cpp
@@ -14,6 +14,8 @@
 #include "sequence.h"
 #include "message_keys.h"
 
+#include <fstream>
+
 namespace Sequencer {
 
   constexpr long CAMERA_PROLOG_TIMEOUT = 6000;  ///< timeout msec to send camera prolog command
@@ -58,6 +60,57 @@ namespace Sequencer {
   /***** Sequencer::Sequence::handletopic_camerad ****************************/
 
 
+  /***** Sequencer::Sequence::handletopic_slicecam_autoacq ********************/
+  /**
+   * @brief      handles slicecamd autoacq status updates
+   * @param[in]  jmessage_in  subscribed-received JSON message
+   *
+   */
+  void Sequence::handletopic_slicecam_autoacq( const nlohmann::json &jmessage_in ) {
+    if ( !jmessage_in.contains("state") ) return;
+    if ( jmessage_in.contains("source") &&
+         jmessage_in.at("source").is_string() &&
+         jmessage_in.at("source").get<std::string>() != "slicecamd" ) return;
+
+    std::string state = jmessage_in.value( "state", "" );
+    std::string message = jmessage_in.value( "message", "" );
+    uint64_t run_id = jmessage_in.value( "run_id", static_cast<uint64_t>(0) );
+
+    bool should_notify = false;
+    bool should_publish = false;
+    {
+      std::lock_guard<std::mutex> lock( this->fine_tune_mtx );
+
+      // Ignore stale messages when waiting on a specific run_id.
+      if ( this->fine_tune_run_id != 0 && run_id != 0 && run_id != this->fine_tune_run_id ) return;
+
+      if ( state == "running" ) {
+        this->fine_tune_active.store( true, std::memory_order_release );
+        this->fine_tune_done = false;
+        this->fine_tune_success = false;
+        this->fine_tune_message = message;
+        should_publish = true;
+      }
+      else if ( state == "success" || state == "failed" || state == "aborted" ) {
+        this->fine_tune_active.store( false, std::memory_order_release );
+        this->fine_tune_done = true;
+        this->fine_tune_success = ( state == "success" );
+        this->fine_tune_message = message;
+        should_notify = true;
+        should_publish = true;
+      }
+      else if ( state == "idle" ) {
+        this->fine_tune_active.store( false, std::memory_order_release );
+        should_publish = true;
+      }
+    }
+
+    if ( should_publish ) this->publish_progress();
+    if ( should_notify ) this->fine_tune_cv.notify_all();
+  }
+  /***** Sequencer::Sequence::handletopic_slicecam_autoacq ********************/
+
+
   /***** Sequencer::Sequence::publish_snapshot *******************************/
   /**
    * @brief      publishes snapshot of my telemetry
@@ -73,6 +126,7 @@ namespace Sequencer {
     this->publish_seqstate();
     this->publish_waitstate();
     this->publish_daemonstate();
+    this->publish_progress();
   }
   /***** Sequencer::Sequence::publish_snapshot *******************************/
 
@@ -193,6 +247,40 @@ namespace Sequencer {
     }
   }
   /***** Sequencer::Sequence::publish_threadstate *****************************/
+
+
+  /***** Sequencer::Sequence::publish_progress ********************************/
+  void Sequence::publish_progress() {
+    nlohmann::json jmessage_out;
+    jmessage_out["source"] = Sequencer::DAEMON_NAME;
+    jmessage_out["fine_tune_active"] = this->fine_tune_active.load(std::memory_order_acquire);
+    jmessage_out["offset_active"] = this->offset_active.load();
+    jmessage_out["offset_settle"] = this->offset_active.load();
+    jmessage_out["ontarget"] = this->is_ontarget.load();
+    jmessage_out["obsid"] = this->target.obsid;
+    jmessage_out["target_state"] = this->target.state;
+    jmessage_out["offset_ra"] = this->target.offset_ra;
+    jmessage_out["offset_dec"] = this->target.offset_dec;
+    jmessage_out["nexp"] = this->target.nexp;
+    jmessage_out["acqmode"] = this->acq_automatic_mode;
+    std::string user_gate_action = "NONE";
+    switch ( this->user_gate_action.load() ) {
+      case USER_GATE_ACQUIRE:      user_gate_action = "ACQUIRE"; break;
+      case USER_GATE_EXPOSE:       user_gate_action = "EXPOSE"; break;
+      case USER_GATE_OFFSET_EXPOSE:user_gate_action = "OFFSET_EXPOSE"; break;
+      default:                     user_gate_action = "NONE"; break;
+    }
+    jmessage_out["user_gate_action"] = user_gate_action;
+    try {
+      this->publisher->publish( jmessage_out, "seq_progress" );
+    }
+    catch ( const std::exception &e ) {
+      logwrite( "Sequencer::Sequence::publish_progress",
+                "ERROR publishing message: "+std::string(e.what()) );
+      return;
+    }
+  }
+  /***** Sequencer::Sequence::publish_progress ********************************/
 
 
   /***** Sequencer::Sequence::broadcast_daemonstate ***************************/
@@ -334,6 +422,28 @@ namespace Sequencer {
                                                 {Sequencer::SEQ_WAIT_EXPOSE} );     // clear EXPOSE
         }
 
+        // Republish EXPTIME messages to ZMQ for seq-progress GUI
+        if ( statstr.compare( 0, 8, "EXPTIME:" ) == 0 ) {
+          std::string vals = statstr.substr(8);
+          std::istringstream iss(vals);
+          int remaining, total, percent;
+          if (iss >> remaining >> total >> percent) {
+            static int last_published_percent = -1;
+            if (percent != last_published_percent) {
+              nlohmann::json jmessage;
+              jmessage["source"] = Sequencer::DAEMON_NAME;
+              jmessage["exptime_remaining_ms"] = remaining;
+              jmessage["exptime_total_ms"] = total;
+              jmessage["exptime_percent"] = percent;
+              try {
+                seq.publisher->publish( jmessage, "seq_progress" );
+                last_published_percent = percent;
+              } catch (...) {
+              }
+            }
+          }
+        }
+
         // ---------------------------------------------
         // clear READOUT flag on the end-of-frame signal
         // ---------------------------------------------
@@ -341,6 +451,22 @@ namespace Sequencer {
         if ( statstr.compare( 0, 10, "FRAMECOUNT" ) == 0 ) {                        // async message tag FRAMECOUNT
           if ( seq.wait_state_manager.is_set( Sequencer::SEQ_WAIT_READOUT ) ) {
             seq.wait_state_manager.clear( Sequencer::SEQ_WAIT_READOUT );
+          }
+          // Parse frame number from "FRAMECOUNT_<dev>:<framenum> rows=X cols=Y"
+          size_t colon_pos = statstr.find(':');
+          if (colon_pos != std::string::npos) {
+            size_t space_pos = statstr.find(' ', colon_pos);
+            try {
+              std::string frame_str = statstr.substr(colon_pos + 1,
+                                                     space_pos == std::string::npos ? std::string::npos : space_pos - colon_pos - 1);
+              int framenum = std::stoi(frame_str);
+              nlohmann::json jmessage;
+              jmessage["source"] = Sequencer::DAEMON_NAME;
+              jmessage["current_frame"] = framenum;
+              jmessage["nexp"] = seq.target.nexp;
+              seq.publisher->publish(jmessage, "seq_progress");
+            } catch (...) {
+            }
           }
         }
 
@@ -481,6 +607,7 @@ namespace Sequencer {
         //
         message.str(""); message << "TARGETSTATE:" << this->target.state << " TARGET:" << this->target.name << " OBSID:" << this->target.obsid;
         this->async.enqueue( message.str() );
+        this->publish_progress();
 #ifdef LOGLEVEL_DEBUG
         logwrite( function, "[DEBUG] target found, starting threads" );
 #endif
@@ -578,40 +705,331 @@ namespace Sequencer {
  *    std::thread( &Sequencer::Sequence::dothread_acquisition, this ).detach();
  ***/
 
-      // If not a calibration target then introduce a pause for the user
-      // to make adjustments, send offsets, etc.
+      // If not a calibration target then handle acquisition automation
       //
       if ( !this->target.iscal ) {
-
-        // waiting for user signal (or cancel)
-        //
-        // The sequencer is effectively paused waiting for user input. This
-        // gives the user a chance to ensure the correct target is on the slit,
-        // select offset stars, etc.
-        //
         {
-        ScopedState wait_state( wait_state_manager, Sequencer::SEQ_WAIT_USER );
-
-        this->async.enqueue_and_log( function, "NOTICE: waiting for USER to send \"continue\" signal" );
-
-        while ( !this->cancel_flag.load() && !this->is_usercontinue.load() ) {
-          std::unique_lock<std::mutex> lock(cv_mutex);
-          this->cv.wait( lock, [this]() { return( this->is_usercontinue.load() || this->cancel_flag.load() ); } );
+        std::stringstream mode_msg;
+        mode_msg << "NOTICE: acquisition automation mode " << this->acq_automatic_mode;
+        this->async.enqueue_and_log( function, mode_msg.str() );
         }
 
-        this->async.enqueue_and_log( function, "NOTICE: received "
-                                               +(this->cancel_flag.load() ? std::string("cancel") : std::string("continue"))
-                                               +" signal!" );
-        }  // end scope for wait_state = WAIT_USER
+        auto wait_for_user = [&](const std::string &notice, UserGateAction action) -> bool {
+          this->is_usercontinue.store(false);
+          ScopedState wait_state( wait_state_manager, Sequencer::SEQ_WAIT_USER );
+          this->user_gate_action.store( action );
+          this->publish_progress();
+          this->async.enqueue_and_log( function, "NOTICE: "+notice );
+          while ( !this->cancel_flag.load() && !this->is_usercontinue.load() ) {
+            std::unique_lock<std::mutex> lock(cv_mutex);
+            this->cv.wait( lock, [this]() { return( this->is_usercontinue.load() || this->cancel_flag.load() ); } );
+          }
+          this->async.enqueue_and_log( function, "NOTICE: received "
+                                                 +(this->cancel_flag.load() ? std::string("cancel") : std::string("continue"))
+                                                 +" signal!" );
+          this->user_gate_action.store( USER_GATE_NONE );
+          this->publish_progress();
+          if ( this->cancel_flag.load() ) return false;
+          this->is_usercontinue.store(false);
+          return true;
+        };
 
-        if ( this->cancel_flag.load() ) {
-          this->async.enqueue_and_log( function, "NOTICE: sequence cancelled" );
-          return;
+        auto wait_for_guiding = [&]() -> long {
+          ScopedState wait_state( wait_state_manager, Sequencer::SEQ_WAIT_GUIDE );
+          this->async.enqueue_and_log( function, "NOTICE: waiting for ACAM guiding" );
+          auto start_time = std::chrono::steady_clock::now();
+          const bool use_timeout = ( this->acquisition_timeout > 0 );
+          const auto timeout = std::chrono::duration<double>( this->acquisition_timeout );
+          while ( !this->cancel_flag.load() ) {
+            std::string reply;
+            if ( this->acamd.command( ACAMD_ACQUIRE, reply ) != NO_ERROR ) {
+              logwrite( function, "ERROR reading ACAM acquire state" );
+              return ERROR;
+            }
+            if ( reply.find( "guiding" ) != std::string::npos ) return NO_ERROR;
+            if ( reply.find( "stopped" ) != std::string::npos ) return ERROR;
+            if ( use_timeout && std::chrono::steady_clock::now() > ( start_time + timeout ) ) return TIMEOUT;
+            std::this_thread::sleep_for( std::chrono::milliseconds(500) );
+          }
+          return ERROR;
+        };
+
+        auto run_fine_tune = [&]() -> long {
+          if ( this->acq_fine_tune_cmd.empty() ) return NO_ERROR;
+          std::string cmd_to_run = this->acq_fine_tune_cmd;
+          std::string acq_logfile;
+          if ( this->acq_fine_tune_log ) {
+            std::string datedir = get_latest_datedir( "/data" );
+            if ( !datedir.empty() ) {
+              std::stringstream logfilename;
+              logfilename << "/data/" << datedir << "/logs/ngps_acq_" << datedir << ".log";
+              acq_logfile = logfilename.str();
+            }
+            else {
+              acq_logfile = "/tmp/ngps_acq.log";
+              this->async.enqueue_and_log( function, "NOTICE: /data datedir not found, logging fine tune output to "+acq_logfile );
+            }
+          }
+
+          auto append_fine_tune_log = [&]( const std::string &line ) {
+            if ( !this->acq_fine_tune_log || acq_logfile.empty() ) return;
+            std::ofstream logfile( acq_logfile, std::ios::app );
+            if ( logfile.is_open() ) {
+              logfile << "=== SEQUENCER: " << line << " ===" << std::endl;
+            }
+          };
+
+          if ( this->acq_fine_tune_log && !acq_logfile.empty() ) {
+            this->async.enqueue_and_log( function, "NOTICE: logging fine tune output to "+acq_logfile );
+          }
+
+          this->async.enqueue_and_log( function, "NOTICE: starting slicecamd autoacq: "+cmd_to_run );
+
+          {
+            std::lock_guard<std::mutex> lock( this->fine_tune_mtx );
+            this->fine_tune_done = false;
+            this->fine_tune_success = false;
+            this->fine_tune_run_id = 0;
+            this->fine_tune_message.clear();
+          }
+
+          std::string start_reply;
+          std::string start_cmd = SLICECAMD_AUTOACQ + " start";
+          if ( !acq_logfile.empty() ) start_cmd += " --log-file " + acq_logfile;
+          if ( !cmd_to_run.empty() ) start_cmd += " " + cmd_to_run;
+          this->fine_tune_active.store( true, std::memory_order_release );
+          this->publish_progress();
+
+          if ( this->slicecamd.command( start_cmd, start_reply ) != NO_ERROR ) {
+            this->fine_tune_active.store( false, std::memory_order_release );
+            this->publish_progress();
+            this->async.enqueue_and_log( function, "ERROR failed to start slicecamd autoacq" );
+            append_fine_tune_log( "failed to start slicecamd autoacq" );
+            return ERROR;
+          }
+
+          auto runpos = start_reply.find( "run_id=" );
+          if ( runpos != std::string::npos ) {
+            try {
+              std::string runid_str = start_reply.substr( runpos + 7 );
+              std::vector<std::string> tokens;
+              Tokenize( runid_str, tokens, " " );
+              if ( !tokens.empty() ) {
+                std::lock_guard<std::mutex> lock( this->fine_tune_mtx );
+                this->fine_tune_run_id = std::stoull( tokens.at(0) );
+              }
+            }
+            catch ( const std::exception & ) { }
+          }
+
+          bool sent_stop = false;
+          bool timed_out = false;
+          auto stop_deadline = std::chrono::steady_clock::time_point::min();
+          auto next_status_poll = std::chrono::steady_clock::now();
+          const bool use_timeout = ( this->acquisition_timeout > 0 );
+          const auto fine_tune_timeout = std::chrono::duration<double>( this->acquisition_timeout );
+          const auto fine_tune_start = std::chrono::steady_clock::now();
+          while ( true ) {
+            {
+              std::unique_lock<std::mutex> lock( this->fine_tune_mtx );
+              if ( this->fine_tune_cv.wait_for( lock, std::chrono::milliseconds(200),
+                                                [this](){ return this->fine_tune_done || this->cancel_flag.load(); } ) ) {
+                if ( this->fine_tune_done ) break;
+              }
+            }
+
+            // Fallback in case status topic messages are delayed or dropped.
+            if ( std::chrono::steady_clock::now() >= next_status_poll ) {
+              next_status_poll = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+              std::string status_reply;
+              if ( this->slicecamd.command( SLICECAMD_AUTOACQ + " status", status_reply ) == NO_ERROR ) {
+                auto pos = status_reply.find( "state=" );
+                if ( pos != std::string::npos ) {
+                  std::string statestr = status_reply.substr( pos + 6 );
+                  std::vector<std::string> tokens;
+                  Tokenize( statestr, tokens, " " );
+                  if ( !tokens.empty() ) {
+                    if ( tokens.at(0) == "success" || tokens.at(0) == "failed" || tokens.at(0) == "aborted" ) {
+                      std::lock_guard<std::mutex> lock( this->fine_tune_mtx );
+                      this->fine_tune_done = true;
+                      if ( timed_out ) {
+                        this->fine_tune_success = false;
+                        this->fine_tune_message = "fine tune timeout";
+                      }
+                      else {
+                        this->fine_tune_success = ( tokens.at(0) == "success" );
+                        this->fine_tune_message = "fine tune " + tokens.at(0);
+                      }
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+
+            if ( use_timeout && !timed_out &&
+                 std::chrono::steady_clock::now() > ( fine_tune_start + fine_tune_timeout ) ) {
+              timed_out = true;
+              this->async.enqueue_and_log( function,
+                                           "ERROR: fine tune timed out after "
+                                           +std::to_string(this->acquisition_timeout)
+                                           +" s; stopping slicecamd autoacq" );
+              {
+                std::lock_guard<std::mutex> lock( this->fine_tune_mtx );
+                this->fine_tune_success = false;
+                this->fine_tune_message = "fine tune timeout";
+              }
+              if ( !sent_stop ) {
+                this->slicecamd.command( SLICECAMD_AUTOACQ + " stop" );
+                sent_stop = true;
+                stop_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+              }
+            }
+
+            if ( timed_out && stop_deadline != std::chrono::steady_clock::time_point::min() &&
+                 std::chrono::steady_clock::now() > stop_deadline ) {
+              std::lock_guard<std::mutex> lock( this->fine_tune_mtx );
+              this->fine_tune_done = true;
+              this->fine_tune_success = false;
+              if ( this->fine_tune_message.empty() ) this->fine_tune_message = "fine tune timeout";
+              break;
+            }
+
+            if ( this->cancel_flag.load() ) {
+              if ( !sent_stop ) {
+                this->async.enqueue_and_log( function, "NOTICE: abort requested; stopping slicecamd autoacq" );
+                this->slicecamd.command( SLICECAMD_AUTOACQ + " stop" );
+                sent_stop = true;
+                stop_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+              }
+              else
+              if ( stop_deadline != std::chrono::steady_clock::time_point::min() &&
+                   std::chrono::steady_clock::now() > stop_deadline ) {
+                break;
+              }
+            }
+          }
+
+          bool success = false;
+          std::string fine_tune_message;
+          {
+            std::lock_guard<std::mutex> lock( this->fine_tune_mtx );
+            success = this->fine_tune_success;
+            fine_tune_message = this->fine_tune_message;
+            this->fine_tune_run_id = 0;
+          }
+
+          this->fine_tune_active.store( false, std::memory_order_release );
+          this->publish_progress();
+
+          if ( success ) {
+            this->async.enqueue_and_log( function, "NOTICE: fine tune complete" );
+            append_fine_tune_log( "fine tune complete" );
+            return NO_ERROR;
+          }
+
+          if ( fine_tune_message.empty() ) fine_tune_message = "fine tune failed";
+          this->async.enqueue_and_log( function, "ERROR: "+fine_tune_message );
+          append_fine_tune_log( fine_tune_message );
+          return ERROR;
+        };
+
+        if ( this->acq_automatic_mode == 1 ) {
+          if ( !wait_for_user( "waiting for USER to send \"continue\" signal", USER_GATE_EXPOSE ) ) {
+            this->async.enqueue_and_log( function, "NOTICE: sequence cancelled" );
+            return;
+          }
         }
+        else {
+          if ( this->acq_automatic_mode == 2 ) {
+            if ( !wait_for_user( "waiting for USER to send \"continue\" signal to start acquisition", USER_GATE_ACQUIRE ) ) {
+              this->async.enqueue_and_log( function, "NOTICE: sequence cancelled" );
+              return;
+            }
+          }
 
-        this->is_usercontinue.store(false);
+          this->async.enqueue_and_log( function, "NOTICE: starting acquisition" );
+          std::thread( &Sequencer::Sequence::dothread_acquisition, this ).detach();
 
-        this->async.enqueue_and_log( function, "NOTICE: received USER continue signal!" );
+          long acqerr = wait_for_guiding();
+          if ( acqerr != NO_ERROR ) {
+            std::string reason = ( acqerr == TIMEOUT ? "timeout" : "error" );
+            this->async.enqueue_and_log( function, "WARNING: failed to reach guiding state ("+reason+"); falling back to manual continue" );
+            UserGateAction gate_action = ( this->target.offset_ra != 0.0 || this->target.offset_dec != 0.0 )
+                                         ? USER_GATE_OFFSET_EXPOSE : USER_GATE_EXPOSE;
+            if ( !wait_for_user( "waiting for USER to send \"continue\" signal to apply offset and expose (guiding failed)", gate_action ) ) {
+              this->async.enqueue_and_log( function, "NOTICE: sequence cancelled" );
+              return;
+            }
+            // Apply offset if target has one, even though guiding failed
+            if ( this->target.offset_ra != 0.0 || this->target.offset_dec != 0.0 ) {
+              // Zero TCS offsets first so observer sees only the target offset
+              this->async.enqueue_and_log( function, "NOTICE: zeroing TCS offsets before applying target offset" );
+              error |= this->tcsd.command( TCSD_NATIVE + " z" );
+              this->async.enqueue_and_log( function, "NOTICE: applying target offset" );
+              this->offset_active.store(true);
+              this->publish_progress();
+              error |= this->target_offset();
+              this->offset_active.store(false);
+              if ( error != NO_ERROR ) {
+                this->thread_error_manager.set( THR_ACQUISITION );
+                this->publish_progress();
+                return;
+              }
+              if ( this->acq_offset_settle > 0 ) {
+                this->async.enqueue_and_log( function, "NOTICE: waiting for offset settle time" );
+                std::this_thread::sleep_for( std::chrono::duration<double>( this->acq_offset_settle ) );
+              }
+              this->publish_progress();
+            }
+          }
+          else {
+            bool fine_tune_ok = ( run_fine_tune() == NO_ERROR );
+            if ( !fine_tune_ok ) {
+              this->async.enqueue_and_log( function, "WARNING: fine tune failed; waiting for USER continue to apply offset and expose" );
+              UserGateAction gate_action = ( this->target.offset_ra != 0.0 || this->target.offset_dec != 0.0 )
+                                           ? USER_GATE_OFFSET_EXPOSE : USER_GATE_EXPOSE;
+              if ( !wait_for_user( "waiting for USER to send \"continue\" signal to apply offset and expose (fine tune failed)", gate_action ) ) {
+                this->async.enqueue_and_log( function, "NOTICE: sequence cancelled" );
+                return;
+              }
+            }
+
+            // acqmode 2: wait for user before offset (only if fine-tune succeeded)
+            if ( fine_tune_ok && this->acq_automatic_mode == 2 ) {
+              UserGateAction gate_action = ( this->target.offset_ra != 0.0 || this->target.offset_dec != 0.0 )
+                                           ? USER_GATE_OFFSET_EXPOSE : USER_GATE_EXPOSE;
+              if ( !wait_for_user( "waiting for USER to send \"continue\" signal to apply offset and expose", gate_action ) ) {
+                this->async.enqueue_and_log( function, "NOTICE: sequence cancelled" );
+                return;
+              }
+            }
+
+            // Apply offset for both acqmode 2 and 3, regardless of fine-tune success
+            // If target has offset defined, apply it before exposing
+            if ( this->target.offset_ra != 0.0 || this->target.offset_dec != 0.0 ) {
+              // Zero TCS offsets first so observer sees only the target offset
+              this->async.enqueue_and_log( function, "NOTICE: zeroing TCS offsets before applying target offset" );
+              error |= this->tcsd.command( TCSD_NATIVE + " z" );
+              std::string mode_str = (this->acq_automatic_mode == 3 && fine_tune_ok) ? "automatically " : "";
+              this->async.enqueue_and_log( function, "NOTICE: applying target offset " + mode_str );
+              this->offset_active.store(true);
+              this->publish_progress();  // Publish offset_active=true
+              error |= this->target_offset();
+              this->offset_active.store(false);
+              if ( error != NO_ERROR ) {
+                this->thread_error_manager.set( THR_ACQUISITION );
+                this->publish_progress();  // Publish with offset error state
+                return;
+              }
+              if ( this->acq_offset_settle > 0 ) {
+                this->async.enqueue_and_log( function, "NOTICE: waiting for offset settle time" );
+                std::this_thread::sleep_for( std::chrono::duration<double>( this->acq_offset_settle ) );
+              }
+              this->publish_progress();  // Publish offset complete
+            }
+          }
+        }
 
         // Ensure slit offset is in "expose" position
         //
@@ -700,6 +1118,7 @@ namespace Sequencer {
       //
       message.str(""); message << "TARGETSTATE:" << this->target.state << " TARGET:" << this->target.name << " OBSID:" << this->target.obsid;
       this->async.enqueue( message.str() );
+      this->publish_progress();
 
       // Check the "dotype" --
       // If this was "do one" then do_once is set and get out now.
@@ -1820,6 +2239,7 @@ namespace Sequencer {
 
     this->thread_error_manager.clear( THR_CAMERA_INIT );   // success
     this->daemon_manager.set( Sequencer::DAEMON_CAMERA );  // camerad ready
+    this->can_expose.store(true, std::memory_order_relaxed);
 
     return NO_ERROR;
   }
@@ -2272,6 +2692,14 @@ namespace Sequencer {
     //
     this->cancel_flag.store(true);
     this->cv.notify_all();
+
+    // request slicecamd to stop autoacq if it is running
+    if ( this->fine_tune_active.load(std::memory_order_acquire) ) {
+      logwrite( function, "NOTICE: stopping slicecamd autoacq" );
+      this->slicecamd.command( SLICECAMD_AUTOACQ + " stop" );
+      this->fine_tune_active.store( false, std::memory_order_release );
+      this->publish_progress();
+    }
 
     // drop into do-one to prevent auto increment to next target
     //
@@ -4635,6 +5063,9 @@ namespace Sequencer {
     //
     if ( testname == "clearlasttarget" ) {
       this->last_target="";
+      this->last_ra_hms="";
+      this->last_dec_dms="";
+      this->async.enqueue_and_log( function, "cleared last target coordinates" );
       error=NO_ERROR;
     }
     else

--- a/sequencerd/sequence.h
+++ b/sequencerd/sequence.h
@@ -15,6 +15,8 @@
 #include <vector>
 #include <chrono>
 #include <atomic>
+#include <cstdint>
+#include <sys/types.h>
 #include <map>
 #include <cmath>
 #include <mysqlx/xdevapi.h>
@@ -154,6 +156,7 @@ namespace Sequencer {
     SEQ_WAIT_TCS,            ///< set when waiting for tcs
     // states
     SEQ_WAIT_ACQUIRE,        ///< set when waiting for acquire
+    SEQ_WAIT_GUIDE,          ///< set when waiting for guiding state
     SEQ_WAIT_EXPOSE,         ///< set when waiting for camera exposure
     SEQ_WAIT_READOUT,        ///< set when waiting for camera readout
     SEQ_WAIT_TCSOP,          ///< set when waiting specifically for tcs operator
@@ -174,10 +177,22 @@ namespace Sequencer {
     {SEQ_WAIT_TCS,      "TCS"},
     // states
     {SEQ_WAIT_ACQUIRE,  "ACQUIRE"},
+    {SEQ_WAIT_GUIDE,    "GUIDE"},
     {SEQ_WAIT_EXPOSE,   "EXPOSE"},
     {SEQ_WAIT_READOUT,  "READOUT"},
     {SEQ_WAIT_TCSOP,    "TCSOP"},
     {SEQ_WAIT_USER,     "USER"}
+  };
+
+  /**
+   * @enum  UserGateAction
+   * @brief explicit action represented by a USER wait gate
+   */
+  enum UserGateAction : int {
+    USER_GATE_NONE = 0,
+    USER_GATE_ACQUIRE,
+    USER_GATE_EXPOSE,
+    USER_GATE_OFFSET_EXPOSE
   };
 
   /**
@@ -288,6 +303,9 @@ namespace Sequencer {
       std::atomic<bool> cancel_flag{false};
       std::atomic<bool> is_ontarget{false};      ///< remotely set by the TCS operator to indicate that the target is ready
       std::atomic<bool> is_usercontinue{false};  ///< remotely set by the user to continue
+      std::atomic<bool> fine_tune_active{false}; ///< fine tune running state reported by slicecamd autoacq
+      std::atomic<bool> offset_active{false};    ///< tracks offset operation in progress
+      std::atomic<int> user_gate_action{USER_GATE_NONE};  ///< explicit USER gate action for GUI labeling
 
       /** @brief  safely runs function in a detached thread using lambda to catch exceptions
        */
@@ -315,6 +333,10 @@ namespace Sequencer {
           arm_readout_flag(false),
           acquisition_timeout(0),
           acquisition_max_retrys(-1),
+          acq_automatic_mode(1),
+          acq_fine_tune_cmd("ngps_acq"),
+          acq_fine_tune_log(false),
+          acq_offset_settle(0),
           tcs_offsetrate_ra(45),
           tcs_offsetrate_dec(45),
           tcs_settle_timeout(10),
@@ -340,7 +362,9 @@ namespace Sequencer {
               { Topic::SNAPSHOT, std::function<void(const nlohmann::json&)>(
                   [this](const nlohmann::json &msg) { handletopic_snapshot(msg); } ) },
               { Topic::CAMERAD, std::function<void(const nlohmann::json&)>(
-                  [this](const nlohmann::json &msg) { handletopic_camerad(msg); } ) }
+                  [this](const nlohmann::json &msg) { handletopic_camerad(msg); } ) },
+              { "slicecam_autoacq", std::function<void(const nlohmann::json&)>(
+                  [this](const nlohmann::json &msg) { handletopic_slicecam_autoacq(msg); } ) }
             };
           }
 
@@ -374,6 +398,10 @@ namespace Sequencer {
 
       double acquisition_timeout; ///< timeout for target acquisition (in sec) set by configuration parameter ACAM_ACQUIRE_TIMEOUT
       int acquisition_max_retrys; ///< max number of acquisition loop attempts
+      int acq_automatic_mode;     ///< acquisition automation mode (1=legacy, 2=semi-auto, 3=auto)
+      std::string acq_fine_tune_cmd; ///< optional fine-tune args override passed to slicecamd autoacq
+      bool acq_fine_tune_log;     ///< log fine-tune output to /data/<datedir>/logs/ngps_acq_<datedir>.log
+      double acq_offset_settle;   ///< seconds to wait after automatic offset
       double tcs_offsetrate_ra;   ///< TCS offset rate RA ("MRATE") in arcsec per second
       double tcs_offsetrate_dec;  ///< TCS offset rate DEC ("MRATE") in arcsec per second
       double tcs_settle_timeout;  ///< timeout for telescope to settle (in sec) set by configuration parameter TCS_SETTLE_TIMEOUT
@@ -389,6 +417,12 @@ namespace Sequencer {
       std::mutex wait_mtx;
       std::condition_variable cv;
       std::mutex cv_mutex;
+      std::mutex fine_tune_mtx;
+      std::condition_variable fine_tune_cv;
+      bool fine_tune_done{false};
+      bool fine_tune_success{false};
+      uint64_t fine_tune_run_id{0};
+      std::string fine_tune_message;
       std::mutex monitor_mtx;
 
       std::map<int, std::string> sequence_states;
@@ -456,12 +490,14 @@ namespace Sequencer {
 
       void handletopic_snapshot( const nlohmann::json &jmessage );
       void handletopic_camerad( const nlohmann::json &jmessage );
+      void handletopic_slicecam_autoacq( const nlohmann::json &jmessage );
       void publish_snapshot();
       void publish_snapshot(std::string &retstring);
       void publish_seqstate();
       void publish_waitstate();
       void publish_daemonstate();
       void publish_threadstate();
+      void publish_progress();
 
       std::unique_ptr<Common::PubSub> publisher;       ///< publisher object
       std::string publisher_address;                   ///< publish socket endpoint

--- a/sequencerd/sequencer_server.cpp
+++ b/sequencerd/sequencer_server.cpp
@@ -392,6 +392,74 @@ namespace Sequencer {
         applied++;
       }
 
+      // ACQ_AUTOMATIC_MODE
+      if (config.param[entry] == "ACQ_AUTOMATIC_MODE") {
+        int mode=1;
+        try {
+          mode = std::stoi( config.arg[entry] );
+          if ( mode < 1 || mode > 3 ) {
+            message.str(""); message << "ERROR: ACQ_AUTOMATIC_MODE " << mode << " out of range {1:3}";
+            this->sequence.async.enqueue_and_log( function, message.str() );
+            return ERROR;
+          }
+        }
+        catch (const std::exception &e) {
+          message.str(""); message << "ERROR parsing ACQ_AUTOMATIC_MODE: " << e.what();
+          this->sequence.async.enqueue_and_log( function, message.str() );
+          return ERROR;
+        }
+        this->sequence.acq_automatic_mode = mode;
+        message.str(""); message << "SEQUENCERD:config:" << config.param[entry] << "=" << config.arg[entry];
+        this->sequence.async.enqueue_and_log( function, message.str() );
+        applied++;
+      }
+
+      // ACQ_FINE_TUNE_CMD
+      if (config.param[entry] == "ACQ_FINE_TUNE_CMD") {
+        this->sequence.acq_fine_tune_cmd = config.arg[entry];
+        message.str(""); message << "SEQUENCERD:config:" << config.param[entry] << "=" << config.arg[entry];
+        this->sequence.async.enqueue_and_log( function, message.str() );
+        applied++;
+      }
+
+      // ACQ_FINE_TUNE_LOG
+      if (config.param[entry] == "ACQ_FINE_TUNE_LOG") {
+        try {
+          int val = std::stoi( config.arg[entry] );
+          this->sequence.acq_fine_tune_log = ( val != 0 );
+        }
+        catch (const std::exception &e) {
+          message.str(""); message << "ERROR parsing ACQ_FINE_TUNE_LOG: " << e.what();
+          this->sequence.async.enqueue_and_log( function, message.str() );
+          return ERROR;
+        }
+        message.str(""); message << "SEQUENCERD:config:" << config.param[entry] << "=" << config.arg[entry];
+        this->sequence.async.enqueue_and_log( function, message.str() );
+        applied++;
+      }
+
+      // ACQ_OFFSET_SETTLE
+      if (config.param[entry] == "ACQ_OFFSET_SETTLE") {
+        double settle=0;
+        try {
+          settle = std::stod( config.arg[entry] );
+          if ( settle < 0 ) {
+            message.str(""); message << "ERROR: ACQ_OFFSET_SETTLE " << settle << " out of range (>=0)";
+            this->sequence.async.enqueue_and_log( function, message.str() );
+            return ERROR;
+          }
+        }
+        catch (const std::exception &e) {
+          message.str(""); message << "ERROR parsing ACQ_OFFSET_SETTLE: " << e.what();
+          this->sequence.async.enqueue_and_log( function, message.str() );
+          return ERROR;
+        }
+        this->sequence.acq_offset_settle = settle;
+        message.str(""); message << "SEQUENCERD:config:" << config.param[entry] << "=" << config.arg[entry];
+        this->sequence.async.enqueue_and_log( function, message.str() );
+        applied++;
+      }
+
       // TCS_WHICH -- which TCS to connect to, defults to real if not specified
       if ( config.param[entry] == "TCS_WHICH" ) {
         if ( config.arg[entry] != "sim" && config.arg[entry] != "real" ) {
@@ -1440,6 +1508,42 @@ namespace Sequencer {
                   this->sequence.usercontinue();
                   std::thread( &Sequencer::Sequence::reset_usercontinue, std::ref(this->sequence) ).detach();
                   ret = NO_ERROR;
+      }
+      else
+
+      // Set/Get acquisition automation mode
+      //
+      if ( cmd == SEQUENCERD_ACQMODE ) {
+                  if ( args.empty() || args == "?" || args == "help" ) {
+                    retstring = SEQUENCERD_ACQMODE + " [ <mode> ]\n";
+                    retstring.append( "  Set or get acquisition automation mode.\n" );
+                    retstring.append( "  <mode> = { 1 (legacy), 2 (semi-auto), 3 (auto) }\n" );
+                    if ( args.empty() ) {
+                      retstring.append( "  current mode = " + std::to_string(this->sequence.acq_automatic_mode) + "\n" );
+                    }
+                    ret = HELP;
+                  }
+                  else {
+                    try {
+                      int mode = std::stoi( args );
+                      if ( mode < 1 || mode > 3 ) {
+                        this->sequence.async.enqueue_and_log( function, "ERROR: acqmode out of range {1:3}" );
+                        ret = ERROR;
+                      }
+                      else {
+                        this->sequence.acq_automatic_mode = mode;
+                        message.str(""); message << "NOTICE: acqmode set to " << mode;
+                        this->sequence.async.enqueue_and_log( function, message.str() );
+                        this->sequence.publish_progress();  // push updated acqmode to seq-progress GUI
+                        retstring = std::to_string( mode );
+                        ret = NO_ERROR;
+                      }
+                    }
+                    catch ( const std::exception & ) {
+                      this->sequence.async.enqueue_and_log( function, "ERROR: invalid acqmode argument" );
+                      ret = ERROR;
+                    }
+                  }
       }
       else
 

--- a/sequencerd/sequencerd.cpp
+++ b/sequencerd/sequencerd.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
 
   // initialize the pub/sub handler
   //
-  if ( sequencerd.sequence.init_pubsub( {"camerad"} ) == ERROR ) {
+  if ( sequencerd.sequence.init_pubsub( {"camerad", "slicecam_autoacq"} ) == ERROR ) {
     logwrite(function, "ERROR initializing publisher-subscriber handler");
     sequencerd.exit_cleanly();
   }

--- a/slicecamd/CMakeLists.txt
+++ b/slicecamd/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required( VERSION 3.12 )
 
 set( SLICECAMD_DIR ${PROJECT_BASE_DIR}/slicecamd )
+set( AUTOACQ_SRC ${SLICECAMD_DIR}/ngps_acq.c )
 
 set( CMAKE_CXX_STANDARD 17 )
 
@@ -25,6 +26,7 @@ find_library( ZMQ_LIB zmq NAMES libzmq PATHS /usr/local/lib )
 #
 find_library( CCFITS_LIB CCfits NAMES libCCfits PATHS /usr/local/lib )
 find_library( CFITS_LIB cfitsio NAMES libcfitsio  PATHS /usr/local/lib )
+find_library( WCS_LIB wcs NAMES libwcs PATHS /usr/local/lib /opt/homebrew/lib )
 
 include_directories( ${PROJECT_BASE_DIR}/utils )
 include_directories( ${PROJECT_BASE_DIR}/Andor )
@@ -38,8 +40,11 @@ add_executable(slicecamd
         ${SLICECAMD_DIR}/slicecam_server.cpp 
         ${SLICECAMD_DIR}/slicecam_interface.cpp 
         ${SLICECAMD_DIR}/slicecam_fits.cpp
+        ${AUTOACQ_SRC}
         ${PYTHON_DEV}
         )
+set_source_files_properties( ${AUTOACQ_SRC}
+                             PROPERTIES COMPILE_FLAGS "-x c -std=gnu11" )
 
 target_link_libraries(slicecamd
         andor
@@ -55,10 +60,12 @@ target_link_libraries(slicecamd
         ${PYTHON_LIB}
         ${CCFITS_LIB}
         ${CFITS_LIB}
+        ${WCS_LIB}
         ${CMAKE_THREAD_LIBS_INIT}
         )
 
 target_compile_options(slicecamd PRIVATE -g -Wall -O1 -Wno-variadic-macros -ggdb)
+target_compile_definitions(slicecamd PRIVATE NGPS_ACQ_EMBEDDED=1)
 
 # -- External Definitions ------------------------------------------------------
 #

--- a/slicecamd/ngps_acq.c
+++ b/slicecamd/ngps_acq.c
@@ -1,0 +1,2535 @@
+// ngps_acq.c
+// NGPS acquisition / fine-acquire helper for the slice-viewing camera.
+//
+// Goals:
+//  - robust source detection + centroiding under poor seeing
+//  - robust statistics before issuing any TCS offset
+//  - reject duplicate frames and frames taken during/just after telescope motion
+//  - optional "manual" frame acquisition via:  scam framegrab one <path>
+//
+// Build (typical on NGPS machines):
+//   gcc -O3 -Wall -Wextra -std=c11 -o ngps_acq ngps_acq.c -lcfitsio -lwcs -lm
+//
+// Example (stream mode, file updated by camera):
+//   ./ngps_acq --input /tmp/slicecam.fits --goal-x 512 --goal-y 512 --loop 1 \
+//              --bg-x1 50 --bg-x2 950 --bg-y1 30 --bg-y2 980 --debug 1
+//
+// Example (manual framegrab mode, synchronous):
+//   ./ngps_acq --frame-mode framegrab --framegrab-out /tmp/ngps_acq.fits \
+//              --goal-x 512 --goal-y 512 --loop 1
+//
+// Notes:
+//  - TCS command assumed:  tcs native pt <dra> <ddec>
+//  - We set native units (dra/ddec arcsec) once per run by default.
+//  - Commanded offsets are computed as (star - goal) (arcsec), i.e. the move
+//    that should place the star on the goal pixel. If your TCS sign convention
+//    is opposite, set --tcs-sign -1.
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <strings.h>
+#include <math.h>
+#include <unistd.h>
+#include <errno.h>
+#include <time.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <limits.h>
+#include <stdarg.h>
+
+#include "fitsio.h"
+#include "ngps_acq_embed.h"
+
+#ifdef __has_include
+#  if __has_include(<wcslib/wcs.h>)
+#    include <wcslib/wcs.h>
+#    include <wcslib/wcshdr.h>
+#  else
+#    include <wcs.h>
+#    include <wcshdr.h>
+#  endif
+#else
+#  include <wcslib/wcs.h>
+#  include <wcslib/wcshdr.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+// ROI mask bits
+#define ROI_X1_SET 0x01
+#define ROI_X2_SET 0x02
+#define ROI_Y1_SET 0x04
+#define ROI_Y2_SET 0x08
+
+typedef enum {
+  FRAME_STREAM = 0,
+  FRAME_FRAMEGRAB = 1
+} FrameMode;
+
+typedef struct {
+  char   input[PATH_MAX];        // stream file path
+
+  FrameMode frame_mode;
+  char   framegrab_out[PATH_MAX];
+  int    framegrab_use_tmp;      // if 1: write to framegrab_out then atomically rename
+
+  double goal_x;
+  double goal_y;
+  int    pixel_origin;           // 0 or 1
+
+  // Candidate search constraints
+  double max_dist_pix;           // circular cut around goal (pix)
+  double snr_thresh;             // detection threshold (sigma)
+  int    min_adjacent;           // raw-pixel neighbors above raw threshold
+
+  // Filtering for detection
+  double filt_sigma_pix;         // Gaussian sigma for smoothing (pix)
+
+  // Centroiding
+  int    centroid_halfwin;       // window half-width (pix)
+  double centroid_sigma_pix;     // Gaussian window sigma (pix)
+  int    centroid_maxiter;
+  double centroid_eps_pix;
+
+  // FITS selection
+  int    extnum;                 // 0=primary, 1=first extension, ...
+  char   extname[32];            // preferred EXTNAME, empty disables
+
+  // Background statistics ROI (inclusive; user origin)
+  int    bg_roi_mask;
+  long   bg_x1, bg_x2, bg_y1, bg_y2;
+
+  // Candidate search ROI (inclusive; user origin)
+  int    search_roi_mask;
+  long   search_x1, search_x2, search_y1, search_y2;
+
+  // Closed-loop / guiding wrapper
+  int    loop;
+  double cadence_sec;            // minimum seconds between accepted samples (stream mode)
+  int    max_samples;            // per-move gather (accepted samples)
+  int    min_samples;            // minimum before testing scatter
+  double prec_arcsec;            // required robust scatter (MAD->sigma) per axis
+  double goal_arcsec;            // convergence threshold on robust offset magnitude
+  int    max_cycles;             // number of move cycles
+  double gain;                   // gain applied to commanded move (0..1 recommended)
+  int    adaptive;               // if 1: adapt exposure + loop thresholds from measured source counts
+  double adaptive_faint;         // start faint adaptation at/under this metric
+  double adaptive_faint_goal;    // faint-mode target metric
+  double adaptive_bright;        // start bright adaptation at/over this metric
+  double adaptive_bright_goal;   // bright-mode target metric
+
+  // Frame quality & safety
+  int    reject_identical;       // reject identical image signatures
+  int    reject_after_move;      // reject N new frames after any TCS move
+  double settle_sec;             // optional sleep after move (additional to rejecting frames)
+  double max_move_arcsec;        // safety cap; do not issue moves larger than this
+  int    continue_on_fail;       // if 0: exit on failure to build stats; if 1: keep trying
+
+  // Offset conventions
+  int    dra_use_cosdec;         // 1: dra = dRA*cos(dec)
+  int    tcs_sign;               // multiply commanded offsets by +/-1
+
+  // TCS options
+  int    tcs_set_units;          // if 1: run "tcs native dra 'arcsec'" and "... ddec 'arcsec'" once
+
+  // SCAM daemon option (guiding-friendly moves)
+  int    use_putonslit;          // if 1: call putonslit <slitra> <slitdec> <crossra> <crossdec>
+  int    wait_guiding;           // if 1: wait for ACAM guiding state after putonslit
+  double guiding_poll_sec;       // polling interval for "acam acquire"
+  double guiding_timeout_sec;    // timeout for waiting on guiding (0 = no timeout)
+
+  // Debug
+  int    debug;
+  char   debug_out[PATH_MAX];
+
+  // General
+  int    dry_run;
+  int    verbose;
+} AcqParams;
+
+typedef struct {
+  int    found;
+  // peak in pixel coords (user origin)
+  double peak_x, peak_y;
+  // centroid (user origin)
+  double cx, cy;
+  // quality
+  double peak_val;
+  double peak_snr_raw;
+  double snr_ap;
+  double src_top10_mean;         // mean of top 10% positive residual pixels in centroid window
+  double bkg;
+  double sigma;
+  // debug ROI bounds (0-based inclusive)
+  long   rx1, rx2, ry1, ry2;     // stats ROI
+  long   sx1, sx2, sy1, sy2;     // search ROI
+} Detection;
+
+typedef struct {
+  int    ok;
+  Detection det;
+
+  // Pixel offsets star - goal (pix)
+  double dx_pix;
+  double dy_pix;
+
+  // WCS
+  int    wcs_ok;
+  double ra_goal_deg, dec_goal_deg;
+  double ra_star_deg, dec_star_deg;
+
+  // Commanded offsets (arcsec) for tcs native pt <dra> <ddec>
+  double dra_cmd_arcsec;
+  double ddec_cmd_arcsec;
+  double r_cmd_arcsec;
+} FrameResult;
+
+typedef struct {
+  time_t mtime;
+  off_t  size;
+  uint64_t sig;        // image signature (subsampled)
+  int have_sig;
+  struct timespec t_accept; // time we accepted this frame
+} FrameState;
+
+typedef enum {
+  ADAPT_MODE_BASELINE = 0,
+  ADAPT_MODE_FAINT = 1,
+  ADAPT_MODE_BRIGHT = 2
+} AdaptiveMode;
+
+typedef struct {
+  AdaptiveMode mode;
+  double cadence_sec;
+  int reject_after_move;
+  double prec_arcsec;
+  double goal_arcsec;
+  int apply_camera;
+  double exptime_sec;
+  int avgframes;
+} AdaptiveCycleConfig;
+
+typedef struct {
+  AdaptiveMode mode;
+  int have_metric;
+  double metric_ewma;
+  int have_last_camera;
+  double last_exptime_sec;
+  int last_avgframes;
+} AdaptiveRuntime;
+
+static volatile sig_atomic_t g_stop = 0;
+static ngps_acq_hooks_t g_hooks;
+static int g_hooks_initialized = 0;
+static void on_sigint(int sig) { (void)sig; g_stop = 1; }
+
+static int stop_requested(void) {
+  if (g_stop) return 1;
+  if (g_hooks_initialized && g_hooks.is_stop_requested) {
+    return g_hooks.is_stop_requested(g_hooks.user) ? 1 : 0;
+  }
+  return 0;
+}
+
+static void acq_vlogf(const char* fmt, va_list ap) {
+  va_list copy;
+  va_copy(copy, ap);
+  vfprintf(stderr, fmt, copy);
+  va_end(copy);
+
+  if (g_hooks_initialized && g_hooks.log_message) {
+    char buffer[2048];
+    va_copy(copy, ap);
+    vsnprintf(buffer, sizeof(buffer), fmt, copy);
+    va_end(copy);
+    g_hooks.log_message(g_hooks.user, buffer);
+  }
+}
+
+static void acq_logf(const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  acq_vlogf(fmt, ap);
+  va_end(ap);
+}
+
+static void die(const char* msg) {
+  acq_logf("FATAL: %s\n", msg);
+  exit(4);
+}
+
+static void sleep_seconds(double sec) {
+  if (sec <= 0) return;
+  struct timespec ts;
+  ts.tv_sec  = (time_t)floor(sec);
+  ts.tv_nsec = (long)((sec - (double)ts.tv_sec) * 1e9);
+  while (nanosleep(&ts, &ts) == -1 && errno == EINTR) {}
+}
+
+static double now_monotonic_sec(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (double)ts.tv_sec + 1e-9*(double)ts.tv_nsec;
+}
+
+static int cmp_float(const void* a, const void* b) {
+  float fa = *(const float*)a;
+  float fb = *(const float*)b;
+  return (fa < fb) ? -1 : (fa > fb) ? 1 : 0;
+}
+
+static int cmp_double(const void* a, const void* b) {
+  double da = *(const double*)a;
+  double db = *(const double*)b;
+  return (da < db) ? -1 : (da > db) ? 1 : 0;
+}
+
+static double wrap_dra_deg(double dra) {
+  while (dra > 180.0) dra -= 360.0;
+  while (dra < -180.0) dra += 360.0;
+  return dra;
+}
+
+// Convert a user-specified ROI into clamped 0-based inclusive bounds.
+// If mask is 0, returns full-frame bounds.
+static void compute_roi_0based(long nx, long ny, int pixel_origin,
+                               int mask, long ux1_in, long ux2_in, long uy1_in, long uy2_in,
+                               long* x1, long* x2, long* y1, long* y2)
+{
+  long ux1 = (pixel_origin == 0) ? 0  : 1;
+  long ux2 = (pixel_origin == 0) ? (nx - 1) : nx;
+  long uy1 = (pixel_origin == 0) ? 0  : 1;
+  long uy2 = (pixel_origin == 0) ? (ny - 1) : ny;
+
+  if (mask & ROI_X1_SET) ux1 = ux1_in;
+  if (mask & ROI_X2_SET) ux2 = ux2_in;
+  if (mask & ROI_Y1_SET) uy1 = uy1_in;
+  if (mask & ROI_Y2_SET) uy2 = uy2_in;
+
+  long ax1 = ux1, ax2 = ux2, ay1 = uy1, ay2 = uy2;
+  if (pixel_origin == 1) { ax1--; ax2--; ay1--; ay2--; }
+
+  if (ax2 < ax1) { long t=ax1; ax1=ax2; ax2=t; }
+  if (ay2 < ay1) { long t=ay1; ay1=ay2; ay2=t; }
+
+  if (ax1 < 0) ax1 = 0;
+  if (ay1 < 0) ay1 = 0;
+  if (ax2 > nx-1) ax2 = nx-1;
+  if (ay2 > ny-1) ay2 = ny-1;
+
+  if (ax2 < ax1) { ax1=0; ax2=nx-1; }
+  if (ay2 < ay1) { ay1=0; ay2=ny-1; }
+
+  *x1=ax1; *x2=ax2; *y1=ay1; *y2=ay2;
+}
+
+// Subsample pixels in ROI into a float array.
+static float* roi_subsample(const float* img, long nx, long ny,
+                            long x1, long x2, long y1, long y2,
+                            long target, long* n_out)
+{
+  if (x1 < 0) x1 = 0;
+  if (y1 < 0) y1 = 0;
+  if (x2 > nx-1) x2 = nx-1;
+  if (y2 > ny-1) y2 = ny-1;
+
+  long wx = x2 - x1 + 1;
+  long wy = y2 - y1 + 1;
+  if (wx <= 0 || wy <= 0) { *n_out = 0; return NULL; }
+
+  long Nroi = wx * wy;
+  long stride = (Nroi > target) ? (Nroi / target) : 1;
+  if (stride < 1) stride = 1;
+
+  long ns = (Nroi + stride - 1) / stride;
+  float* sample = (float*)malloc((size_t)ns * sizeof(float));
+  if (!sample) die("malloc sample failed");
+
+  long k = 0;
+  long idx = 0;
+  for (long y = y1; y <= y2; y++) {
+    long row0 = y * nx;
+    for (long x = x1; x <= x2; x++, idx++) {
+      if ((idx % stride) == 0) sample[k++] = img[row0 + x];
+    }
+  }
+
+  *n_out = k;
+  return sample;
+}
+
+// SExtractor-like background + sigma estimation within ROI:
+//  - initial median + MAD
+//  - iterative sigma-clipping around median
+//  - background via mode = 2.5*median - 1.5*mean (unless skewed, then median)
+static void bg_sigma_sextractor_like(const float* img, long nx, long ny,
+                                     long x1, long x2, long y1, long y2,
+                                     double* bkg_out, double* sigma_out)
+{
+  *bkg_out = 0.0;
+  *sigma_out = 1.0;
+
+  long ns = 0;
+  float* sample = roi_subsample(img, nx, ny, x1, x2, y1, y2, 200000, &ns);
+  if (!sample || ns < 64) {
+    if (sample) free(sample);
+    return;
+  }
+
+  qsort(sample, (size_t)ns, sizeof(float), cmp_float);
+  double median = (ns % 2) ? sample[ns/2] : 0.5*(sample[ns/2 - 1] + sample[ns/2]);
+
+  // MAD
+  float* dev = (float*)malloc((size_t)ns * sizeof(float));
+  if (!dev) die("malloc dev failed");
+  for (long i = 0; i < ns; i++) dev[i] = (float)fabs((double)sample[i] - median);
+  qsort(dev, (size_t)ns, sizeof(float), cmp_float);
+  double mad = (ns % 2) ? dev[ns/2] : 0.5*(dev[ns/2 - 1] + dev[ns/2]);
+  free(dev);
+
+  double sigma = 1.4826 * mad;
+  if (!isfinite(sigma) || sigma <= 0) sigma = 1.0;
+
+  // Iterative clip
+  const double clip = 3.0;
+  double mean = median;
+  double sigma_prev = sigma;
+  for (int it = 0; it < 8; it++) {
+    double lo = median - clip * sigma;
+    double hi = median + clip * sigma;
+
+    double sum = 0.0, sum2 = 0.0;
+    long n = 0;
+    for (long i = 0; i < ns; i++) {
+      double v = sample[i];
+      if (v < lo || v > hi) continue;
+      sum += v;
+      sum2 += v*v;
+      n++;
+    }
+    if (n < 32) break;
+
+    mean = sum / (double)n;
+    double var = (sum2 / (double)n) - mean*mean;
+    if (var < 0) var = 0;
+    sigma = sqrt(var);
+    if (!isfinite(sigma) || sigma <= 0) sigma = sigma_prev;
+
+    double rel = fabs(sigma - sigma_prev) / (sigma_prev > 0 ? sigma_prev : 1.0);
+    sigma_prev = sigma;
+    if (rel < 0.01) break;
+  }
+
+  double mode = 2.5*median - 1.5*mean;
+  double bkg = mode;
+  if (sigma > 0 && (mean - median)/sigma > 0.3) bkg = median;
+  if (!isfinite(bkg)) bkg = median;
+  if (!isfinite(sigma) || sigma <= 0) sigma = 1.0;
+
+  *bkg_out = bkg;
+  *sigma_out = sigma;
+
+  free(sample);
+}
+
+static double median_of_doubles(double* a, int n)
+{
+  if (n <= 0) return 0.0;
+  qsort(a, (size_t)n, sizeof(double), cmp_double);
+  return (n % 2) ? a[n/2] : 0.5*(a[n/2 - 1] + a[n/2]);
+}
+
+static double mad_sigma_of_doubles(const double* a_in, int n, double med)
+{
+  if (n <= 1) return 0.0;
+  double* d = (double*)malloc((size_t)n * sizeof(double));
+  if (!d) die("malloc mad failed");
+  for (int i = 0; i < n; i++) d[i] = fabs(a_in[i] - med);
+  qsort(d, (size_t)n, sizeof(double), cmp_double);
+  double mad = (n % 2) ? d[n/2] : 0.5*(d[n/2 - 1] + d[n/2]);
+  free(d);
+  return 1.4826 * mad;
+}
+
+// Gaussian kernel (1D) normalized to sum=1.
+static double* make_gaussian_kernel(double sigma, int* radius_out)
+{
+  if (sigma <= 0.2) sigma = 0.2;
+  int r = (int)ceil(3.0*sigma);
+  if (r < 1) r = 1;
+  int len = 2*r + 1;
+  double* k = (double*)malloc((size_t)len * sizeof(double));
+  if (!k) die("malloc kernel failed");
+
+  double sum = 0.0;
+  for (int i = -r; i <= r; i++) {
+    double x = (double)i / sigma;
+    double v = exp(-0.5 * x * x);
+    k[i+r] = v;
+    sum += v;
+  }
+  if (sum <= 0) sum = 1.0;
+  for (int i = 0; i < len; i++) k[i] /= sum;
+
+  *radius_out = r;
+  return k;
+}
+
+static double kernel_sum_sq(const double* k, int radius)
+{
+  int len = 2*radius + 1;
+  double s2 = 0.0;
+  for (int i = 0; i < len; i++) s2 += k[i]*k[i];
+  return s2;
+}
+
+// Separable convolution on a patch (w*h). Border handling: clamp.
+static void convolve_separable(const float* in, float* tmp, float* out,
+                               int w, int h, const double* k, int r)
+{
+  // horizontal
+  for (int y = 0; y < h; y++) {
+    const float* row = in + y*w;
+    float* trow = tmp + y*w;
+    for (int x = 0; x < w; x++) {
+      double acc = 0.0;
+      for (int dx = -r; dx <= r; dx++) {
+        int xx = x + dx;
+        if (xx < 0) xx = 0;
+        if (xx >= w) xx = w-1;
+        acc += (double)row[xx] * k[dx+r];
+      }
+      trow[x] = (float)acc;
+    }
+  }
+
+  // vertical
+  for (int y = 0; y < h; y++) {
+    float* orow = out + y*w;
+    for (int x = 0; x < w; x++) {
+      double acc = 0.0;
+      for (int dy = -r; dy <= r; dy++) {
+        int yy = y + dy;
+        if (yy < 0) yy = 0;
+        if (yy >= h) yy = h-1;
+        acc += (double)tmp[yy*w + x] * k[dy+r];
+      }
+      orow[x] = (float)acc;
+    }
+  }
+}
+
+// Simple debug drawing (PPM)
+static void set_px(uint8_t* rgb, int w, int h, int x, int y, uint8_t r, uint8_t g, uint8_t b)
+{
+  if (x < 0 || y < 0 || x >= w || y >= h) return;
+  size_t idx = (size_t)(y*w + x) * 3;
+  rgb[idx+0] = r;
+  rgb[idx+1] = g;
+  rgb[idx+2] = b;
+}
+
+static void draw_plus(uint8_t* rgb, int w, int h, int x, int y, int rad, uint8_t r, uint8_t g, uint8_t b)
+{
+  for (int dx = -rad; dx <= rad; dx++) set_px(rgb, w, h, x+dx, y, r,g,b);
+  for (int dy = -rad; dy <= rad; dy++) set_px(rgb, w, h, x, y+dy, r,g,b);
+}
+
+static void draw_x(uint8_t* rgb, int w, int h, int x, int y, int rad, uint8_t r, uint8_t g, uint8_t b)
+{
+  for (int d = -rad; d <= rad; d++) {
+    set_px(rgb, w, h, x+d, y+d, r,g,b);
+    set_px(rgb, w, h, x+d, y-d, r,g,b);
+  }
+}
+
+static void draw_circle(uint8_t* rgb, int w, int h, int xc, int yc, int rad, uint8_t r, uint8_t g, uint8_t b)
+{
+  int x = rad;
+  int y = 0;
+  int err = 0;
+  while (x >= y) {
+    set_px(rgb,w,h, xc + x, yc + y, r,g,b);
+    set_px(rgb,w,h, xc + y, yc + x, r,g,b);
+    set_px(rgb,w,h, xc - y, yc + x, r,g,b);
+    set_px(rgb,w,h, xc - x, yc + y, r,g,b);
+    set_px(rgb,w,h, xc - x, yc - y, r,g,b);
+    set_px(rgb,w,h, xc - y, yc - x, r,g,b);
+    set_px(rgb,w,h, xc + y, yc - x, r,g,b);
+    set_px(rgb,w,h, xc + x, yc - y, r,g,b);
+    y++;
+    if (err <= 0) {
+      err += 2*y + 1;
+    } else {
+      x--;
+      err += 2*(y - x) + 1;
+    }
+  }
+}
+
+static void draw_line(uint8_t* rgb, int w, int h, int x0, int y0, int x1, int y1, uint8_t r, uint8_t g, uint8_t b)
+{
+  int dx = abs(x1 - x0), sx = (x0 < x1) ? 1 : -1;
+  int dy = -abs(y1 - y0), sy = (y0 < y1) ? 1 : -1;
+  int err = dx + dy;
+  while (1) {
+    set_px(rgb,w,h,x0,y0,r,g,b);
+    if (x0 == x1 && y0 == y1) break;
+    int e2 = 2*err;
+    if (e2 >= dy) { err += dy; x0 += sx; }
+    if (e2 <= dx) { err += dx; y0 += sy; }
+  }
+}
+
+static void draw_arrow(uint8_t* rgb, int w, int h, int x0, int y0, int x1, int y1, uint8_t r, uint8_t g, uint8_t b)
+{
+  draw_line(rgb,w,h,x0,y0,x1,y1,r,g,b);
+  double ang = atan2((double)(y1 - y0), (double)(x1 - x0));
+  double a1 = ang + M_PI/8.0;
+  double a2 = ang - M_PI/8.0;
+  int L = 10;
+  int hx1 = x1 - (int)lround(L * cos(a1));
+  int hy1 = y1 - (int)lround(L * sin(a1));
+  int hx2 = x1 - (int)lround(L * cos(a2));
+  int hy2 = y1 - (int)lround(L * sin(a2));
+  draw_line(rgb,w,h,x1,y1,hx1,hy1,r,g,b);
+  draw_line(rgb,w,h,x1,y1,hx2,hy2,r,g,b);
+}
+
+static int write_debug_ppm(const char* outpath,
+                           const float* img, long nx,
+                           long rx1, long rx2, long ry1, long ry2,
+                           double bkg, double sigma, double snr_thresh,
+                           const Detection* det,
+                           const AcqParams* p)
+{
+  int w = (int)(rx2 - rx1 + 1);
+  int h = (int)(ry2 - ry1 + 1);
+  if (w <= 0 || h <= 0) return 1;
+
+  uint8_t* rgb = (uint8_t*)malloc((size_t)w * (size_t)h * 3);
+  if (!rgb) return 2;
+
+  double vmin = bkg - 2.0*sigma;
+  double vmax = bkg + 6.0*sigma;
+  double inv = (vmax > vmin) ? (1.0/(vmax - vmin)) : 1.0;
+
+  for (int yy = 0; yy < h; yy++) {
+    long y = ry1 + yy;
+    for (int xx = 0; xx < w; xx++) {
+      long x = rx1 + xx;
+      double v = img[y*nx + x];
+      double t = (v - vmin) * inv;
+      if (t < 0) t = 0;
+      if (t > 1) t = 1;
+      uint8_t g = (uint8_t)lround(255.0 * t);
+      size_t idx = (size_t)(yy*w + xx) * 3;
+      rgb[idx+0] = g;
+      rgb[idx+1] = g;
+      rgb[idx+2] = g;
+
+      double snr = (sigma > 0) ? ((v - bkg) / sigma) : 0;
+      if (snr >= snr_thresh) {
+        // color above-threshold pixels (cyan-ish)
+        rgb[idx+0] = (uint8_t)((int)rgb[idx+0] / 2);
+        rgb[idx+1] = 255;
+        rgb[idx+2] = 255;
+      }
+    }
+  }
+
+  if (det && det->found) {
+    int px0 = (p->pixel_origin == 0) ? (int)lround(det->peak_x) : (int)lround(det->peak_x - 1.0);
+    int py0 = (p->pixel_origin == 0) ? (int)lround(det->peak_y) : (int)lround(det->peak_y - 1.0);
+    int cx0 = (p->pixel_origin == 0) ? (int)lround(det->cx)     : (int)lround(det->cx - 1.0);
+    int cy0 = (p->pixel_origin == 0) ? (int)lround(det->cy)     : (int)lround(det->cy - 1.0);
+
+    int gx0 = (p->pixel_origin == 0) ? (int)lround(p->goal_x)   : (int)lround(p->goal_x - 1.0);
+    int gy0 = (p->pixel_origin == 0) ? (int)lround(p->goal_y)   : (int)lround(p->goal_y - 1.0);
+
+    // shift into ROI image coordinates
+    int px = px0 - (int)rx1;
+    int py = py0 - (int)ry1;
+    int cx = cx0 - (int)rx1;
+    int cy = cy0 - (int)ry1;
+    int gx = gx0 - (int)rx1;
+    int gy = gy0 - (int)ry1;
+
+    draw_circle(rgb, w, h, px, py, 10, 255, 50, 50);
+    draw_plus(rgb,   w, h, cx, cy, 6,  50, 255, 50);
+    draw_x(rgb,      w, h, gx, gy, 8,  255, 255, 0);
+    draw_arrow(rgb,  w, h, cx, cy, gx, gy, 255, 200, 0);
+  }
+
+  FILE* f = fopen(outpath, "wb");
+  if (!f) { free(rgb); return 3; }
+  fprintf(f, "P6\n%d %d\n255\n", w, h);
+  fwrite(rgb, 1, (size_t)w*(size_t)h*3, f);
+  fclose(f);
+  free(rgb);
+  return 0;
+}
+
+// --- FITS I/O helpers ---
+static int move_to_image_hdu_by_extname(fitsfile* fptr, const char* want_extname, int* out_hdu_index, int* status)
+{
+  if (!want_extname || want_extname[0] == '\0') return 1;
+
+  int nhdus = 0;
+  if (fits_get_num_hdus(fptr, &nhdus, status)) return 2;
+
+  for (int hdu = 1; hdu <= nhdus; hdu++) {
+    int hdutype = 0;
+    if (fits_movabs_hdu(fptr, hdu, &hdutype, status)) return 3;
+    if (hdutype != IMAGE_HDU) continue;
+
+    char extname[FLEN_VALUE] = {0};
+    int keystat = 0;
+    if (fits_read_key(fptr, TSTRING, "EXTNAME", extname, NULL, &keystat)) {
+      extname[0] = '\0';
+    }
+
+    if (extname[0] && strcasecmp(extname, want_extname) == 0) {
+      if (out_hdu_index) *out_hdu_index = hdu;
+      return 0;
+    }
+  }
+
+  return 4;
+}
+
+static int read_fits_image_and_header(const char* path, const AcqParams* p,
+                                      float** img_out, long* nx_out, long* ny_out,
+                                      char** header_out, int* nkeys_out,
+                                      int* used_hdu_out, char* used_extname_out, size_t used_extname_sz,
+                                      double* exptime_sec_out)
+{
+  fitsfile* fptr = NULL;
+  int status = 0;
+
+  if (fits_open_file(&fptr, path, READONLY, &status)) return status;
+
+  int used_hdu = 1;
+  char used_extname[FLEN_VALUE] = {0};
+
+  // Prefer EXTNAME
+  if (p->extname[0]) {
+    int found_hdu = 0;
+    int rc = move_to_image_hdu_by_extname(fptr, p->extname, &found_hdu, &status);
+    if (rc == 0) {
+      used_hdu = found_hdu;
+    } else {
+      if (p->verbose) acq_logf( "WARNING: EXTNAME='%s' not found; falling back to extnum=%d\n", p->extname, p->extnum);
+      status = 0;
+      int hdutype = 0;
+      if (fits_movabs_hdu(fptr, p->extnum + 1, &hdutype, &status)) {
+        fits_close_file(fptr, &status);
+        return status;
+      }
+      used_hdu = p->extnum + 1;
+    }
+  } else {
+    int hdutype = 0;
+    if (fits_movabs_hdu(fptr, p->extnum + 1, &hdutype, &status)) {
+      fits_close_file(fptr, &status);
+      return status;
+    }
+    used_hdu = p->extnum + 1;
+  }
+
+  // record EXTNAME
+  {
+    int keystat = 0;
+    if (fits_read_key(fptr, TSTRING, "EXTNAME", used_extname, NULL, &keystat)) {
+      used_extname[0] = '\0';
+    }
+  }
+
+  // record EXPTIME (fallback to 1s if unavailable)
+  double exptime_sec = 1.0;
+  {
+    int keystat = 0;
+    double exptmp = 0.0;
+    if (!fits_read_key(fptr, TDOUBLE, "EXPTIME", &exptmp, NULL, &keystat) &&
+        isfinite(exptmp) && exptmp > 0.0) {
+      exptime_sec = exptmp;
+    }
+  }
+
+  int bitpix = 0, naxis = 0;
+  long naxes[3] = {0,0,0};
+  if (fits_get_img_param(fptr, 3, &bitpix, &naxis, naxes, &status)) {
+    fits_close_file(fptr, &status);
+    return status;
+  }
+  if (naxis < 2) {
+    fits_close_file(fptr, &status);
+    return BAD_NAXIS;
+  }
+
+  long nx = naxes[0];
+  long ny = naxes[1];
+
+  float* img = (float*)malloc((size_t)nx * (size_t)ny * sizeof(float));
+  if (!img) {
+    fits_close_file(fptr, &status);
+    return MEMORY_ALLOCATION;
+  }
+
+  long fpixel[3] = {1,1,1};
+  long nelem = nx * ny;
+  int anynul = 0;
+  if (fits_read_pix(fptr, TFLOAT, fpixel, nelem, NULL, img, &anynul, &status)) {
+    free(img);
+    fits_close_file(fptr, &status);
+    return status;
+  }
+
+  char* header = NULL;
+  int nkeys = 0;
+  int hstatus = 0;
+  if (fits_hdr2str(fptr, 1, NULL, 0, &header, &nkeys, &hstatus)) {
+    header = NULL;
+    nkeys = 0;
+  }
+
+  fits_close_file(fptr, &status);
+
+  *img_out = img;
+  *nx_out  = nx;
+  *ny_out  = ny;
+  *header_out = header;
+  *nkeys_out  = nkeys;
+  if (used_hdu_out) *used_hdu_out = used_hdu;
+  if (used_extname_out && used_extname_sz > 0) {
+    snprintf(used_extname_out, used_extname_sz, "%s", used_extname);
+  }
+  if (exptime_sec_out) *exptime_sec_out = exptime_sec;
+
+  return 0;
+}
+
+// --- WCS helpers ---
+static int init_wcs_from_header(const char* header, int nkeys, struct wcsprm** wcs_out, int* nwcs_out)
+{
+  if (!header || nkeys <= 0) return 1;
+
+  int relax = WCSHDR_all;
+  int ctrl  = 2;
+  int nrej = 0, nwcs = 0;
+  struct wcsprm* wcs = NULL;
+
+  int stat = wcspih((char*)header, nkeys, relax, ctrl, &nrej, &nwcs, &wcs);
+  if (stat || nwcs < 1 || !wcs) return 2;
+
+  if (wcsset(&wcs[0])) {
+    wcsvfree(&nwcs, &wcs);
+    return 3;
+  }
+
+  *wcs_out = wcs;
+  *nwcs_out = nwcs;
+  return 0;
+}
+
+// Pixel -> (RA,Dec) degrees using WCSLIB. Inputs are FITS 1-based pixels.
+static int pix2world_wcs(const struct wcsprm* wcs0, double pix_x, double pix_y,
+                         double* ra_deg, double* dec_deg)
+{
+  if (!wcs0) return 1;
+
+  double pixcrd[2] = {pix_x, pix_y};
+  double imgcrd[2] = {0,0};
+  double phi=0, theta=0;
+  double world[2] = {0,0};
+  int stat[2] = {0,0};
+
+  int rc = wcsp2s((struct wcsprm*)wcs0, 1, 2, pixcrd, imgcrd, &phi, &theta, world, stat);
+  if (rc) return 2;
+
+  *ra_deg  = world[0];
+  *dec_deg = world[1];
+  return 0;
+}
+
+// --- Frame signature (reject identical) ---
+static uint64_t fnv1a64_init(void) { return 1469598103934665603ULL; }
+static uint64_t fnv1a64_step(uint64_t h, uint64_t x) {
+  h ^= x;
+  return h * 1099511628211ULL;
+}
+
+static uint64_t image_signature_subsample(const float* img, long nx, long ny,
+                                          long x1, long x2, long y1, long y2)
+{
+  if (!img || nx <= 0 || ny <= 0) return 0;
+  if (x1 < 0) x1 = 0;
+  if (y1 < 0) y1 = 0;
+  if (x2 > nx-1) x2 = nx-1;
+  if (y2 > ny-1) y2 = ny-1;
+  if (x2 < x1 || y2 < y1) return 0;
+
+  long wx = x2 - x1 + 1;
+  long wy = y2 - y1 + 1;
+  long N = wx * wy;
+
+  // Aim for ~50k samples max.
+  long target = 50000;
+  long stride = (N > target) ? (N / target) : 1;
+  if (stride < 1) stride = 1;
+
+  uint64_t h = fnv1a64_init();
+  long idx = 0;
+  for (long y = y1; y <= y2; y++) {
+    long row0 = y * nx;
+    for (long x = x1; x <= x2; x++, idx++) {
+      if ((idx % stride) != 0) continue;
+      // quantize float to int32 with mild scaling to be stable
+      float v = img[row0 + x];
+      int32_t q = (int32_t)lrintf(v * 8.0f);
+      h = fnv1a64_step(h, (uint64_t)(uint32_t)q);
+    }
+  }
+  // Mix in ROI bounds to reduce accidental collisions
+  h = fnv1a64_step(h, (uint64_t)(uint32_t)x1);
+  h = fnv1a64_step(h, (uint64_t)(uint32_t)y1);
+  h = fnv1a64_step(h, (uint64_t)(uint32_t)x2);
+  h = fnv1a64_step(h, (uint64_t)(uint32_t)y2);
+  return h;
+}
+
+// --- TCS helpers ---
+static int tcs_set_native_units(int dry_run, int verbose)
+{
+  if (g_hooks_initialized && g_hooks.tcs_set_native_units) {
+    return g_hooks.tcs_set_native_units(g_hooks.user, dry_run, verbose);
+  }
+
+  const char* cmd1 = "tcs native dra 'arcsec'";
+  const char* cmd2 = "tcs native ddec 'arcsec'";
+  if (verbose || dry_run) {
+    acq_logf( "TCS CMD: %s\n", cmd1);
+    acq_logf( "TCS CMD: %s\n", cmd2);
+  }
+  if (dry_run) return 0;
+  int rc1 = system(cmd1);
+  int rc2 = system(cmd2);
+  if (rc1 != 0 || rc2 != 0) {
+    acq_logf( "WARNING: TCS unit command failed rc1=%d rc2=%d\n", rc1, rc2);
+    return 1;
+  }
+  return 0;
+}
+
+static int tcs_move_arcsec(double dra_arcsec, double ddec_arcsec, int dry_run, int verbose)
+{
+  if (g_hooks_initialized && g_hooks.tcs_move_arcsec) {
+    return g_hooks.tcs_move_arcsec(g_hooks.user, dra_arcsec, ddec_arcsec, dry_run, verbose);
+  }
+
+  char cmd[512];
+  snprintf(cmd, sizeof(cmd), "tcs native pt %.3f %.3f", dra_arcsec, ddec_arcsec);
+  if (verbose || dry_run) acq_logf( "TCS CMD: %s\n", cmd);
+  if (dry_run) return 0;
+
+  int rc = system(cmd);
+  if (rc != 0) {
+    acq_logf( "WARNING: TCS command returned %d\n", rc);
+    return 1;
+  }
+  return 0;
+}
+
+// --- SCAM daemon helper (guiding-friendly move) ---
+static double wrap_ra_deg(double ra)
+{
+  // keep in [0,360)
+  while (ra < 0.0)   ra += 360.0;
+  while (ra >= 360.0) ra -= 360.0;
+  return ra;
+}
+
+// Convert desired PT offsets (arcsec) into a synthetic "crosshair" RA/Dec given a "slit" RA/Dec.
+// This preserves robust median offset logic while still invoking putonslit (which computes PT internally).
+static void slit_cross_from_offsets(const AcqParams* p,
+                                    double slit_ra_deg, double slit_dec_deg,
+                                    double dra_arcsec, double ddec_arcsec,
+                                    double* cross_ra_deg, double* cross_dec_deg)
+{
+  double cosdec = cos(slit_dec_deg * M_PI / 180.0);
+  double ddec_deg = ddec_arcsec / 3600.0;
+
+  double dra_deg = dra_arcsec / 3600.0;
+  if (p->dra_use_cosdec) {
+    // dra_arcsec was computed as dRA*cos(dec)*3600, so invert the cos(dec) here.
+    double denom = (fabs(cosdec) > 1e-12) ? cosdec : (cosdec >= 0 ? 1e-12 : -1e-12);
+    dra_deg /= denom;
+  }
+
+  *cross_dec_deg = slit_dec_deg + ddec_deg;
+  *cross_ra_deg  = wrap_ra_deg(slit_ra_deg + dra_deg);
+}
+
+// Hard-coded interface: call via the SCAM daemon.
+// Intentionally NOT user-adjustable.
+static int scam_putonslit_deg(double slit_ra_deg, double slit_dec_deg,
+                              double cross_ra_deg, double cross_dec_deg,
+                              int dry_run, int verbose)
+{
+  if (g_hooks_initialized && g_hooks.scam_putonslit_deg) {
+    return g_hooks.scam_putonslit_deg(g_hooks.user,
+                                      slit_ra_deg, slit_dec_deg,
+                                      cross_ra_deg, cross_dec_deg,
+                                      dry_run, verbose);
+  }
+
+  char cmd[1024];
+  // putonslit <slitra> <slitdec> <crossra> <crossdec>  (all decimal degrees)
+  snprintf(cmd, sizeof(cmd), "scam putonslit %.10f %.10f %.10f %.10f",
+           slit_ra_deg, slit_dec_deg, cross_ra_deg, cross_dec_deg);
+
+  if (verbose || dry_run) acq_logf( "SCAM CMD: %s\n", cmd);
+  if (dry_run) return 0;
+
+  int rc = system(cmd);
+  if (rc != 0) {
+    acq_logf( "WARNING: putonslit command returned %d\n", rc);
+    return 1;
+  }
+  return 0;
+}
+
+// --- ACAM guiding state helpers ---
+static int acam_query_state(char* state, size_t state_sz, int verbose)
+{
+  if (g_hooks_initialized && g_hooks.acam_query_state) {
+    return g_hooks.acam_query_state(g_hooks.user, state, state_sz, verbose);
+  }
+
+  if (!state || state_sz == 0) return 2;
+  state[0] = '\0';
+
+  FILE* fp = popen("acam acquire", "r");
+  if (!fp) {
+    if (verbose) acq_logf( "WARNING: failed to run 'acam acquire': %s\n", strerror(errno));
+    return 1;
+  }
+
+  char buf[256];
+  int found = 0;
+  while (fgets(buf, sizeof(buf), fp)) {
+    if (strcasestr(buf, "guiding")) {
+      snprintf(state, state_sz, "guiding");
+      found = 1;
+    } else if (strcasestr(buf, "acquiring")) {
+      snprintf(state, state_sz, "acquiring");
+      found = 1;
+    }
+  }
+
+  int rc = pclose(fp);
+  if (rc != 0 && verbose) {
+    acq_logf( "WARNING: 'acam acquire' returned %d\n", rc);
+  }
+
+  return found ? 0 : 2;
+}
+
+static int wait_for_guiding(const AcqParams* p)
+{
+  if (!p->wait_guiding || p->dry_run) return 0;
+
+  const double poll_sec = (p->guiding_poll_sec > 0) ? p->guiding_poll_sec : 1.0;
+  const double timeout_sec = p->guiding_timeout_sec;
+
+  double t0 = now_monotonic_sec();
+  char last_state[32] = {0};
+  int warned = 0;
+
+  for (;;) {
+    if (stop_requested()) return 2;
+
+    char state[32] = {0};
+    int rc = acam_query_state(state, sizeof(state), p->verbose);
+    if (rc == 0) {
+      if (strcmp(state, last_state) != 0) {
+        if (p->verbose) acq_logf( "ACAM state: %s\n", state);
+        snprintf(last_state, sizeof(last_state), "%s", state);
+      }
+      if (!strcmp(state, "guiding")) return 0;
+    } else {
+      if (!warned) {
+        acq_logf( "WARNING: could not determine ACAM state; will keep polling.\n");
+        warned = 1;
+      }
+    }
+
+    if (timeout_sec > 0) {
+      double dt = now_monotonic_sec() - t0;
+      if (dt >= timeout_sec) {
+        acq_logf( "WARNING: timed out waiting for guiding (%.1fs).\n", timeout_sec);
+        return 1;
+      }
+    }
+
+    sleep_seconds(poll_sec);
+  }
+}
+
+
+// --- Camera command helpers ---
+static int scam_framegrab_one(const char* outpath, int verbose)
+{
+  if (g_hooks_initialized && g_hooks.scam_framegrab_one) {
+    return g_hooks.scam_framegrab_one(g_hooks.user, outpath, verbose);
+  }
+
+  char cmd[PATH_MAX + 128];
+  // We assume scam writes the file atomically enough; if not, stream stability check handles it.
+  snprintf(cmd, sizeof(cmd), "scam framegrab one %s", outpath);
+  if (verbose) acq_logf( "CAM CMD: %s\n", cmd);
+  int rc = system(cmd);
+  if (rc != 0) {
+    acq_logf( "WARNING: framegrab command failed (rc=%d)\n", rc);
+    return 1;
+  }
+  return 0;
+}
+
+static int scam_set_exptime(double exptime_sec, int dry_run, int verbose)
+{
+  if (g_hooks_initialized && g_hooks.scam_set_exptime) {
+    return g_hooks.scam_set_exptime(g_hooks.user, exptime_sec, dry_run, verbose);
+  }
+
+  if (!isfinite(exptime_sec) || exptime_sec <= 0) return 1;
+  char cmd[256];
+  snprintf(cmd, sizeof(cmd), "scam exptime %.3f", exptime_sec);
+  if (verbose || dry_run) acq_logf( "SCAM CMD: %s\n", cmd);
+  if (dry_run) return 0;
+  int rc = system(cmd);
+  if (rc != 0) {
+    acq_logf( "WARNING: scam exptime command failed (rc=%d)\n", rc);
+    return 1;
+  }
+  return 0;
+}
+
+static int scam_set_avgframes(int avgframes, int dry_run, int verbose)
+{
+  if (g_hooks_initialized && g_hooks.scam_set_avgframes) {
+    return g_hooks.scam_set_avgframes(g_hooks.user, avgframes, dry_run, verbose);
+  }
+
+  if (avgframes < 1) avgframes = 1;
+  char cmd[256];
+  snprintf(cmd, sizeof(cmd), "scam avgframes %d", avgframes);
+  if (verbose || dry_run) acq_logf( "SCAM CMD: %s\n", cmd);
+  if (dry_run) return 0;
+  int rc = system(cmd);
+  if (rc != 0) {
+    acq_logf( "WARNING: scam avgframes command failed (rc=%d)\n", rc);
+    return 1;
+  }
+  return 0;
+}
+
+static const char* adaptive_mode_name(AdaptiveMode m)
+{
+  if (m == ADAPT_MODE_FAINT) return "faint";
+  if (m == ADAPT_MODE_BRIGHT) return "bright";
+  return "baseline";
+}
+
+static AdaptiveMode adaptive_next_mode(AdaptiveMode current, double metric, const AcqParams* p)
+{
+  if (!isfinite(metric) || metric <= 0) return current;
+
+  // Hysteresis prevents flapping when source counts jitter near thresholds.
+  const double faint_enter = p->adaptive_faint;
+  const double faint_exit  = p->adaptive_faint * 1.15;
+  const double bright_enter = p->adaptive_bright;
+  const double bright_exit  = p->adaptive_bright * 0.85;
+
+  if (current == ADAPT_MODE_FAINT) {
+    if (metric >= bright_enter) return ADAPT_MODE_BRIGHT;
+    return (metric >= faint_exit) ? ADAPT_MODE_BASELINE : ADAPT_MODE_FAINT;
+  }
+  if (current == ADAPT_MODE_BRIGHT) {
+    if (metric <= faint_enter) return ADAPT_MODE_FAINT;
+    return (metric <= bright_exit) ? ADAPT_MODE_BASELINE : ADAPT_MODE_BRIGHT;
+  }
+
+  if (metric <= faint_enter) return ADAPT_MODE_FAINT;
+  if (metric >= bright_enter) return ADAPT_MODE_BRIGHT;
+  return ADAPT_MODE_BASELINE;
+}
+
+static int adaptive_bright_avg_target(double metric, double goal_metric)
+{
+  double ratio = (goal_metric > 0) ? (metric / goal_metric) : 1.0;
+  if (!isfinite(ratio)) ratio = 1.0;
+  if (ratio > 8.0) return 5;
+  if (ratio > 4.0) return 4;
+  if (ratio > 2.0) return 3;
+  if (ratio > 1.2) return 2;
+  return 1;
+}
+
+static void adaptive_build_cycle_config(const AcqParams* p, const AdaptiveRuntime* rt,
+                                        AdaptiveMode mode, double metric, AdaptiveCycleConfig* cfg)
+{
+  memset(cfg, 0, sizeof(*cfg));
+  cfg->mode = mode;
+  cfg->cadence_sec = p->cadence_sec;
+  cfg->reject_after_move = p->reject_after_move;
+  cfg->prec_arcsec = p->prec_arcsec;
+  cfg->goal_arcsec = p->goal_arcsec;
+
+  double cur_exp = (rt && rt->have_last_camera) ? rt->last_exptime_sec : 1.0;
+  int cur_avg = (rt && rt->have_last_camera) ? rt->last_avgframes : 1;
+  if (!isfinite(cur_exp) || cur_exp <= 0) cur_exp = 1.0;
+  if (cur_exp < 0.1) cur_exp = 0.1;
+  if (cur_exp > 15.0) cur_exp = 15.0;
+  if (cur_avg < 1) cur_avg = 1;
+  if (cur_avg > 5) cur_avg = 5;
+  cfg->exptime_sec = cur_exp;
+  cfg->avgframes = cur_avg;
+
+  if (mode == ADAPT_MODE_BASELINE) return;
+
+  double goal_metric = (mode == ADAPT_MODE_FAINT) ? p->adaptive_faint_goal : p->adaptive_bright_goal;
+  if (!isfinite(goal_metric) || goal_metric <= 0) {
+    goal_metric = (mode == ADAPT_MODE_FAINT) ? p->adaptive_faint : p->adaptive_bright;
+  }
+
+  double factor = 1.0;
+  if (isfinite(metric) && metric > 0 && isfinite(goal_metric) && goal_metric > 0) {
+    double lo = goal_metric * 0.85;
+    double hi = goal_metric * 1.15;
+    if (metric < lo || metric > hi) {
+      factor = sqrt(goal_metric / metric);
+      if (!isfinite(factor) || factor <= 0) factor = 1.0;
+      if (factor < 0.5) factor = 0.5;
+      if (factor > 2.0) factor = 2.0;
+    }
+  }
+
+  double target_exp = cur_exp * factor;
+  if (target_exp < 0.1) target_exp = 0.1;
+  if (target_exp > 15.0) target_exp = 15.0;
+
+  int target_avg = cur_avg;
+  if (mode == ADAPT_MODE_BRIGHT) {
+    int desired = adaptive_bright_avg_target(metric, goal_metric);
+    if (target_avg < desired) target_avg++;
+    else if (target_avg > desired) target_avg--;
+  } else if (mode == ADAPT_MODE_FAINT) {
+    if (target_avg > 1) target_avg--;
+    else if (target_avg < 1) target_avg++;
+    cfg->reject_after_move = (p->reject_after_move > 1) ? 1 : p->reject_after_move;
+    cfg->prec_arcsec = fmax(p->prec_arcsec, 0.20);
+    cfg->goal_arcsec = fmax(p->goal_arcsec, 0.30);
+  }
+
+  cfg->exptime_sec = target_exp;
+  cfg->avgframes = target_avg;
+  cfg->apply_camera = (fabs(target_exp - cur_exp) >= 0.02 || target_avg != cur_avg);
+
+  double min_cadence = cfg->exptime_sec * (double)cfg->avgframes + 0.20;
+  cfg->cadence_sec = fmax(cfg->cadence_sec, min_cadence);
+}
+
+static int adaptive_apply_camera(const AcqParams* p, AdaptiveRuntime* rt, const AdaptiveCycleConfig* cfg)
+{
+  if (!p->adaptive) return 0;
+  if (!cfg->apply_camera) return 0;
+
+  int rc = 0;
+  if (scam_set_exptime(cfg->exptime_sec, p->dry_run, p->verbose)) rc = 1;
+  if (scam_set_avgframes(cfg->avgframes, p->dry_run, p->verbose)) rc = 1;
+  rt->have_last_camera = 1;
+  rt->last_exptime_sec = cfg->exptime_sec;
+  rt->last_avgframes = cfg->avgframes;
+  return rc;
+}
+
+static void adaptive_update_metric_and_mode(const AcqParams* p, AdaptiveRuntime* rt, double cycle_metric)
+{
+  if (!p->adaptive) return;
+  if (!isfinite(cycle_metric) || cycle_metric <= 0) return;
+
+  if (!rt->have_metric) {
+    rt->metric_ewma = cycle_metric;
+    rt->have_metric = 1;
+  } else {
+    const double alpha = 0.35;
+    double lprev = log(fmax(rt->metric_ewma, 1e-6));
+    double lnow  = log(fmax(cycle_metric, 1e-6));
+    rt->metric_ewma = exp((1.0 - alpha) * lprev + alpha * lnow);
+  }
+
+  rt->mode = adaptive_next_mode(rt->mode, rt->metric_ewma, p);
+}
+
+static void adaptive_finish_cycle(const AcqParams* p, AdaptiveRuntime* rt,
+                                  const double* metric_samp, int n)
+{
+  if (!p->adaptive || n <= 0) return;
+
+  double mtmp[n];
+  for (int i = 0; i < n; i++) mtmp[i] = metric_samp[i];
+  double cycle_metric = median_of_doubles(mtmp, n);
+
+  AdaptiveMode prev = rt->mode;
+  adaptive_update_metric_and_mode(p, rt, cycle_metric);
+
+  if (p->verbose) {
+    if (prev != rt->mode) {
+      acq_logf( "Adaptive transition: %s -> %s  cycle_metric=%.1f ewma=%.1f\n",
+              adaptive_mode_name(prev), adaptive_mode_name(rt->mode),
+              cycle_metric, rt->metric_ewma);
+    } else {
+      acq_logf( "Adaptive hold: mode=%s cycle_metric=%.1f ewma=%.1f\n",
+              adaptive_mode_name(rt->mode), cycle_metric, rt->metric_ewma);
+    }
+  }
+}
+
+static double source_top_fraction_mean(const float* img, long nx, long ny,
+                                       const Detection* d, const AcqParams* p,
+                                       double frac)
+{
+  if (!img || !d || !p || nx <= 0 || ny <= 0) return 0.0;
+  if (!d->found) return 0.0;
+  if (!isfinite(frac) || frac <= 0 || frac > 1) frac = 0.10;
+
+  double cx0 = (p->pixel_origin == 0) ? d->cx : (d->cx - 1.0);
+  double cy0 = (p->pixel_origin == 0) ? d->cy : (d->cy - 1.0);
+
+  long xlo = (long)floor(cx0) - p->centroid_halfwin;
+  long xhi = (long)floor(cx0) + p->centroid_halfwin;
+  long ylo = (long)floor(cy0) - p->centroid_halfwin;
+  long yhi = (long)floor(cy0) + p->centroid_halfwin;
+
+  if (xlo < d->sx1) xlo = d->sx1;
+  if (xhi > d->sx2) xhi = d->sx2;
+  if (ylo < d->sy1) ylo = d->sy1;
+  if (yhi > d->sy2) yhi = d->sy2;
+
+  if (xhi < xlo || yhi < ylo) return 0.0;
+
+  long maxn = (xhi - xlo + 1) * (yhi - ylo + 1);
+  if (maxn <= 0) return 0.0;
+
+  float* vals = (float*)malloc((size_t)maxn * sizeof(float));
+  if (!vals) return 0.0;
+
+  long n = 0;
+  for (long y = ylo; y <= yhi; y++) {
+    long row0 = y * nx;
+    for (long x = xlo; x <= xhi; x++) {
+      double v = (double)img[row0 + x] - d->bkg;
+      if (v > 0) vals[n++] = (float)v;
+    }
+  }
+
+  if (n <= 0) {
+    free(vals);
+    return 0.0;
+  }
+
+  qsort(vals, (size_t)n, sizeof(float), cmp_float);
+
+  long k = (long)ceil(frac * (double)n);
+  if (k < 1) k = 1;
+  if (k > n) k = n;
+
+  long start = n - k;
+  double sum = 0.0;
+  for (long i = start; i < n; i++) sum += (double)vals[i];
+
+  free(vals);
+  return sum / (double)k;
+}
+
+// --- Detection + centroiding ---
+static Detection detect_star_near_goal(const float* img, long nx, long ny, const AcqParams* p)
+{
+  Detection d;
+  memset(&d, 0, sizeof(d));
+
+  // Stats ROI
+  compute_roi_0based(nx, ny, p->pixel_origin,
+                     p->bg_roi_mask, p->bg_x1, p->bg_x2, p->bg_y1, p->bg_y2,
+                     &d.rx1, &d.rx2, &d.ry1, &d.ry2);
+
+  // Search ROI (defaults to stats ROI)
+  if (p->search_roi_mask == 0) {
+    d.sx1 = d.rx1; d.sx2 = d.rx2; d.sy1 = d.ry1; d.sy2 = d.ry2;
+  } else {
+    compute_roi_0based(nx, ny, p->pixel_origin,
+                       p->search_roi_mask, p->search_x1, p->search_x2, p->search_y1, p->search_y2,
+                       &d.sx1, &d.sx2, &d.sy1, &d.sy2);
+  }
+
+  // Background and sigma from stats ROI
+  bg_sigma_sextractor_like(img, nx, ny, d.rx1, d.rx2, d.ry1, d.ry2, &d.bkg, &d.sigma);
+  if (!isfinite(d.sigma) || d.sigma <= 0) {
+    d.found = 0;
+    return d;
+  }
+
+  // Goal (0-based)
+  double goal_x0 = (p->pixel_origin == 0) ? p->goal_x : (p->goal_x - 1.0);
+  double goal_y0 = (p->pixel_origin == 0) ? p->goal_y : (p->goal_y - 1.0);
+
+  // Build detection patch (search ROI) and background-subtract
+  int w = (int)(d.sx2 - d.sx1 + 1);
+  int h = (int)(d.sy2 - d.sy1 + 1);
+  if (w <= 3 || h <= 3) {
+    d.found = 0;
+    return d;
+  }
+
+  float* patch = (float*)malloc((size_t)w*(size_t)h*sizeof(float));
+  float* tmp   = (float*)malloc((size_t)w*(size_t)h*sizeof(float));
+  float* filt  = (float*)malloc((size_t)w*(size_t)h*sizeof(float));
+  if (!patch || !tmp || !filt) die("malloc patch/tmp/filt failed");
+
+  for (int yy = 0; yy < h; yy++) {
+    long y = d.sy1 + yy;
+    long row0 = y * nx;
+    float* prow = patch + (size_t)yy*(size_t)w;
+    for (int xx = 0; xx < w; xx++) {
+      long x = d.sx1 + xx;
+      double v = (double)img[row0 + x] - d.bkg;
+      // keep negatives; filter uses them too
+      prow[xx] = (float)v;
+    }
+  }
+
+  // Filter for detection
+  int kr = 0;
+  double* k = make_gaussian_kernel(p->filt_sigma_pix, &kr);
+  convolve_separable(patch, tmp, filt, w, h, k, kr);
+  double sumsq1d = kernel_sum_sq(k, kr);
+  free(k);
+
+  // Detection threshold in filtered image
+  // For separable 2D kernel, sigma_filt = sigma_raw * sqrt(sum(K^2)) = sigma_raw * sumsq1d
+  double sigma_filt = d.sigma * sumsq1d;
+  if (!isfinite(sigma_filt) || sigma_filt <= 0) sigma_filt = d.sigma;
+  double thr_filt = p->snr_thresh * sigma_filt;
+
+  // Raw threshold for adjacency check
+  double thr_raw = p->snr_thresh * d.sigma;
+
+  // Search best local maximum
+  double best_val = -1e300;
+  int best_x = -1, best_y = -1;
+  double best_snr_raw = 0;
+
+  for (int yy = 1; yy < h-1; yy++) {
+    for (int xx = 1; xx < w-1; xx++) {
+      float v = filt[(size_t)yy*(size_t)w + (size_t)xx];
+      if ((double)v < thr_filt) continue;
+
+      // local max in filtered
+      if (v < filt[(size_t)yy*(size_t)w + (size_t)(xx-1)]) continue;
+      if (v < filt[(size_t)yy*(size_t)w + (size_t)(xx+1)]) continue;
+      if (v < filt[(size_t)(yy-1)*(size_t)w + (size_t)xx]) continue;
+      if (v < filt[(size_t)(yy+1)*(size_t)w + (size_t)xx]) continue;
+
+      long x0 = d.sx1 + xx;
+      long y0 = d.sy1 + yy;
+
+      // within max distance from goal
+      double dxg = (double)x0 - goal_x0;
+      double dyg = (double)y0 - goal_y0;
+      if (hypot(dxg, dyg) > p->max_dist_pix) continue;
+
+      // adjacency check in raw residual image (patch)
+      int nadj = 0;
+      for (int dy = -1; dy <= 1; dy++) {
+        for (int dx = -1; dx <= 1; dx++) {
+          if (dx == 0 && dy == 0) continue;
+          float rv = patch[(size_t)(yy+dy)*(size_t)w + (size_t)(xx+dx)];
+          if ((double)rv > thr_raw) nadj++;
+        }
+      }
+      if (nadj < p->min_adjacent) continue;
+
+      // best peak by raw peak value at that location (not filtered)
+      float rawv = patch[(size_t)yy*(size_t)w + (size_t)xx];
+      double snr_here = (d.sigma > 0) ? ((double)rawv / d.sigma) : 0;
+      if ((double)rawv > best_val) {
+        best_val = (double)rawv;
+        best_x = (int)x0;
+        best_y = (int)y0;
+        best_snr_raw = snr_here;
+      }
+    }
+  }
+
+  if (best_x < 0) {
+    free(patch); free(tmp); free(filt);
+    d.found = 0;
+    return d;
+  }
+
+  // Iterative Gaussian-windowed centroid on raw residuals (img - bkg)
+  double cx = (double)best_x;
+  double cy = (double)best_y;
+
+  int hw = p->centroid_halfwin;
+  double s2 = p->centroid_sigma_pix * p->centroid_sigma_pix;
+  if (s2 <= 0.1) s2 = 0.1;
+
+  double sumI = 0, sumX = 0, sumY = 0;
+  for (int it = 0; it < p->centroid_maxiter; it++) {
+    long xlo = (long)floor(cx) - hw;
+    long xhi = (long)floor(cx) + hw;
+    long ylo = (long)floor(cy) - hw;
+    long yhi = (long)floor(cy) + hw;
+
+    // clamp to search ROI
+    if (xlo < d.sx1) xlo = d.sx1;
+    if (xhi > d.sx2) xhi = d.sx2;
+    if (ylo < d.sy1) ylo = d.sy1;
+    if (yhi > d.sy2) yhi = d.sy2;
+
+    sumI = sumX = sumY = 0.0;
+    for (long y = ylo; y <= yhi; y++) {
+      long row0 = y * nx;
+      for (long x = xlo; x <= xhi; x++) {
+        double I = (double)img[row0 + x] - d.bkg;
+        if (I <= 0) continue;
+        double dx = (double)x - cx;
+        double dy = (double)y - cy;
+        double wgt = exp(-0.5*(dx*dx + dy*dy)/s2);
+        double ww = wgt * I;
+        sumI += ww;
+        sumX += ww * (double)x;
+        sumY += ww * (double)y;
+      }
+    }
+
+    if (sumI <= 0) break;
+
+    double nxp = sumX / sumI;
+    double nyp = sumY / sumI;
+
+    double shift = hypot(nxp - cx, nyp - cy);
+    cx = nxp;
+    cy = nyp;
+
+    if (shift < p->centroid_eps_pix) break;
+  }
+
+  if (sumI <= 0 || !isfinite(cx) || !isfinite(cy)) {
+    free(patch); free(tmp); free(filt);
+    d.found = 0;
+    return d;
+  }
+
+  // aperture-like SNR within centroid window
+  long xlo = (long)floor(cx) - hw;
+  long xhi = (long)floor(cx) + hw;
+  long ylo = (long)floor(cy) - hw;
+  long yhi = (long)floor(cy) + hw;
+  if (xlo < d.sx1) xlo = d.sx1;
+  if (xhi > d.sx2) xhi = d.sx2;
+  if (ylo < d.sy1) ylo = d.sy1;
+  if (yhi > d.sy2) yhi = d.sy2;
+
+  double sig_sum = 0.0;
+  long npix = 0;
+  for (long y = ylo; y <= yhi; y++) {
+    long row0 = y * nx;
+    for (long x = xlo; x <= xhi; x++) {
+      double I = (double)img[row0 + x] - d.bkg;
+      if (I <= 0) continue;
+      sig_sum += I;
+      npix++;
+    }
+  }
+  double noise = d.sigma * sqrt((double)(npix > 1 ? npix : 1));
+  double snr_ap = (noise > 0) ? (sig_sum / noise) : 0.0;
+
+  d.found = 1;
+  d.peak_val = best_val;
+  d.peak_snr_raw = best_snr_raw;
+  d.snr_ap = snr_ap;
+
+  d.peak_x = (p->pixel_origin == 0) ? (double)best_x : (double)best_x + 1.0;
+  d.peak_y = (p->pixel_origin == 0) ? (double)best_y : (double)best_y + 1.0;
+  d.cx     = (p->pixel_origin == 0) ? cx          : cx + 1.0;
+  d.cy     = (p->pixel_origin == 0) ? cy          : cy + 1.0;
+  d.src_top10_mean = source_top_fraction_mean(img, nx, ny, &d, p, 0.10);
+
+  free(patch); free(tmp); free(filt);
+  return d;
+}
+
+// Compute a full FrameResult from an already-loaded FITS image and header.
+static FrameResult solve_frame(const float* img, long nx, long ny, const char* header, int nkeys, const AcqParams* p)
+{
+  FrameResult r;
+  memset(&r, 0, sizeof(r));
+
+  r.det = detect_star_near_goal(img, nx, ny, p);
+  if (!r.det.found) {
+    r.ok = 0;
+    return r;
+  }
+
+  r.dx_pix = r.det.cx - p->goal_x;
+  r.dy_pix = r.det.cy - p->goal_y;
+
+  // WCS
+  struct wcsprm* wcs = NULL;
+  int nwcs = 0;
+  int wcs_stat = init_wcs_from_header(header, nkeys, &wcs, &nwcs);
+  if (wcs_stat != 0) {
+    r.wcs_ok = 0;
+    r.ok = 0;
+    return r;
+  }
+
+  // Convert pixels to FITS 1-based for wcsp2s
+  double goal_x1 = (p->pixel_origin == 0) ? (p->goal_x + 1.0) : p->goal_x;
+  double goal_y1 = (p->pixel_origin == 0) ? (p->goal_y + 1.0) : p->goal_y;
+  double star_x1 = (p->pixel_origin == 0) ? (r.det.cx + 1.0)   : r.det.cx;
+  double star_y1 = (p->pixel_origin == 0) ? (r.det.cy + 1.0)   : r.det.cy;
+
+  if (pix2world_wcs(&wcs[0], goal_x1, goal_y1, &r.ra_goal_deg, &r.dec_goal_deg) ||
+      pix2world_wcs(&wcs[0], star_x1, star_y1, &r.ra_star_deg, &r.dec_star_deg)) {
+    r.wcs_ok = 0;
+    r.ok = 0;
+    wcsvfree(&nwcs, &wcs);
+    return r;
+  }
+
+  wcsvfree(&nwcs, &wcs);
+
+  r.wcs_ok = 1;
+
+  // Commanded offsets: (star - goal)
+  double dra_deg  = wrap_dra_deg(r.ra_star_deg - r.ra_goal_deg);
+  double ddec_deg = (r.dec_star_deg - r.dec_goal_deg);
+
+  double cosdec = cos(r.dec_goal_deg * M_PI / 180.0);
+  double dra_arcsec = dra_deg * 3600.0;
+  if (p->dra_use_cosdec) dra_arcsec *= cosdec;
+  double ddec_arcsec = ddec_deg * 3600.0;
+
+  dra_arcsec  *= (double)p->tcs_sign;
+  ddec_arcsec *= (double)p->tcs_sign;
+
+  r.dra_cmd_arcsec = dra_arcsec;
+  r.ddec_cmd_arcsec = ddec_arcsec;
+  r.r_cmd_arcsec = hypot(dra_arcsec, ddec_arcsec);
+
+  // Final accept criteria for "good sample"
+  //  - windowed SNR must be >= threshold (it is typically more stable than raw peak SNR)
+  if (r.det.snr_ap < p->snr_thresh) {
+    r.ok = 0;
+    return r;
+  }
+
+  r.ok = 1;
+  return r;
+}
+
+// --- Frame acquisition / gating ---
+static int stat_file(const char* path, struct stat* st)
+{
+  if (stat(path, st) != 0) return 1;
+  if (st->st_size <= 0) return 2;
+  return 0;
+}
+
+static int wait_for_stream_update(const char* path, FrameState* fs, double settle_check_sec, double cadence_sec, int verbose)
+{
+  // Wait until file mtime/size changes from last accepted, then is stable across settle_check_sec.
+  // Also enforce a minimum time between accepted frames (cadence_sec).
+  struct stat st1, st2;
+  for (;;) {
+    if (stop_requested()) return 2;
+
+    if (stat_file(path, &st1) != 0) {
+      sleep_seconds(0.1);
+      continue;
+    }
+
+    // Newness check
+    if (fs->mtime == st1.st_mtime && fs->size == st1.st_size) {
+      sleep_seconds(0.1);
+      continue;
+    }
+
+    // Stability check (not writing)
+    sleep_seconds(settle_check_sec);
+    if (stat_file(path, &st2) != 0) {
+      sleep_seconds(0.1);
+      continue;
+    }
+    if (st2.st_mtime != st1.st_mtime || st2.st_size != st1.st_size) {
+      // still changing
+      sleep_seconds(0.05);
+      continue;
+    }
+
+    // Cadence check
+    if (cadence_sec > 0) {
+      double tnow = now_monotonic_sec();
+      double tlast = (double)fs->t_accept.tv_sec + 1e-9*(double)fs->t_accept.tv_nsec;
+      if (tlast > 0 && (tnow - tlast) < cadence_sec) {
+        sleep_seconds(0.05);
+        continue;
+      }
+    }
+
+    // accept this as a candidate to read
+    if (verbose) {
+      acq_logf( "Frame candidate: mtime=%ld size=%ld\n", (long)st2.st_mtime, (long)st2.st_size);
+    }
+    fs->mtime = st2.st_mtime;
+    fs->size = st2.st_size;
+    clock_gettime(CLOCK_MONOTONIC, &fs->t_accept);
+    return 0;
+  }
+}
+
+// Read next frame into memory (img/header) according to frame_mode.
+// Returns 0 on success.
+static int acquire_next_frame(const AcqParams* p, FrameState* fs,
+                              double cadence_sec,
+                              float** img_out, long* nx_out, long* ny_out,
+                              char** header_out, int* nkeys_out,
+                              double* exptime_sec_out)
+{
+  const char* path = NULL;
+
+  if (p->frame_mode == FRAME_FRAMEGRAB) {
+    // Acquire synchronously via scam
+    if (scam_framegrab_one(p->framegrab_out, p->verbose)) return 2;
+    // Give filesystem a tiny moment; and then read when stable
+    // (framegrab should generally be complete when system() returns, but be safe)
+    (void)wait_for_stream_update(p->framegrab_out, fs, 0.05, 0.0, 0);
+    path = p->framegrab_out;
+  } else {
+    // Stream mode: wait until file updates
+    if (wait_for_stream_update(p->input, fs, 0.05, cadence_sec, 0)) return 3;
+    path = p->input;
+  }
+
+  int used_hdu = 0;
+  char used_extname[64] = {0};
+  double exptime_sec = 1.0;
+  int st = read_fits_image_and_header(path, p, img_out, nx_out, ny_out, header_out, nkeys_out,
+                                      &used_hdu, used_extname, sizeof(used_extname),
+                                      &exptime_sec);
+  if (st) {
+    acq_logf( "ERROR: CFITSIO read failed for %s (status=%d)\n", path, st);
+    return 4;
+  }
+  if (exptime_sec_out) *exptime_sec_out = exptime_sec;
+  return 0;
+}
+
+// --- CLI ---
+static void usage(const char* argv0)
+{
+  acq_logf(
+    "Usage: %s --input PATH --goal-x X --goal-y Y [options]\n"
+    "\n"
+    "Core options:\n"
+    "  --input PATH                 Streamed FITS file path (default /tmp/slicecam.fits)\n"
+    "  --goal-x X --goal-y Y        Goal pixel coordinates\n"
+    "  --pixel-origin 0|1           Coordinate origin for goal/ROI (default 0)\n"
+    "\n"
+    "Frame acquisition:\n"
+    "  --frame-mode stream|framegrab    (default stream)\n"
+    "  --framegrab-out PATH             Output FITS path for framegrab (default /tmp/ngps_acq.fits)\n"
+    "\n"
+    "Detection / centroiding:\n"
+    "  --snr S                     SNR threshold (sigma) (default 8)\n"
+    "  --max-dist PIX               Search radius around goal (default 200)\n"
+    "  --min-adj N                  Min adjacent raw pixels above threshold (default 4)\n"
+    "  --filt-sigma PIX             Detection filter sigma (default 1.2)\n"
+    "  --centroid-hw N              Centroid half-window (default 6)\n"
+    "  --centroid-sigma PIX         Centroid window sigma (default 2.0)\n"
+    "\n"
+    "FITS selection:\n"
+    "  --extname NAME               Prefer this EXTNAME (default L). Use 'none' to disable.\n"
+    "  --extnum N                   Fallback HDU index (0=primary,1=first ext...) (default 1)\n"
+    "\n"
+    "ROIs (inclusive bounds; same origin as goal):\n"
+    "  --bg-x1 N --bg-x2 N --bg-y1 N --bg-y2 N        Background/stats ROI\n"
+    "  --search-x1 N --search-x2 N --search-y1 N --search-y2 N  Search ROI (defaults to bg ROI)\n"
+    "\n"
+    "Closed-loop acquisition:\n"
+    "  --loop 0|1                   Enable closed-loop mode (default 0)\n"
+    "  --cadence-sec S              Minimum seconds between accepted frames (stream) (default 0.0)\n"
+    "  --max-samples N              Samples to collect per move (default 10)\n"
+    "  --min-samples N              Minimum before evaluating precision (default 3)\n"
+    "  --prec-arcsec A              Required robust scatter per axis (default 0.1)\n"
+    "  --goal-arcsec A              Converge threshold on |offset| (default 0.1)\n"
+    "  --max-cycles N               Move cycles (default 20)\n"
+    "  --gain G                     Gain applied to move (default 0.7)\n"
+    "  --adaptive 0|1               Adaptive extremes-only mode (default 0)\n"
+    "  --adaptive-faint X           Start faint adaptation when metric <= X (default 500)\n"
+    "  --adaptive-faint-goal X      Faint-mode target metric (default 500)\n"
+    "  --adaptive-bright Y          Start bright adaptation when metric >= Y (default 10000)\n"
+    "  --adaptive-bright-goal Y     Bright-mode target metric (default 10000)\n"
+    "                               Metric is top-10%% mean source counts (background-subtracted).\n"
+    "                               In-range [faint,bright] keeps baseline behavior.\n"
+    "\n"
+    "Robustness / safety:\n"
+    "  --reject-identical 0|1       Reject identical frames (default 1)\n"
+    "  --reject-after-move N        Reject N new frames after move (default 2)\n"
+    "  --settle-sec S               Sleep after move (default 0.0)\n"
+    "  --max-move-arcsec A          Do not issue moves larger than this (default 10)\n"
+    "  --continue-on-fail 0|1       If 0: exit on failure; if 1: keep trying (default 0)\n"
+    "\n"
+    "TCS conventions:\n"
+    "  --tcs-set-units 0|1          Set native dra/ddec units to arcsec once (default 1)\n"
+    "  --use-putonslit 0|1          Use scam daemon putonslit for moves (default 0)\n"
+    "  --dra-use-cosdec 0|1         dra = dRA*cos(dec) (default 1)\n"
+    "  --tcs-sign +1|-1             Multiply commanded offsets by sign (default +1)\n"
+    "\n"
+    "Guiding wait (after putonslit):\n"
+    "  --wait-guiding 0|1           Wait for ACAM guiding state after putonslit (default 1)\n"
+    "  --guiding-poll-sec S         Poll period for 'acam acquire' (default 1.0)\n"
+    "  --guiding-timeout-sec S      Timeout waiting for guiding; 0=wait forever (default 120)\n"
+    "\n"
+    "Debug:\n"
+    "  --debug 0|1                  Write overlay PPM (default 0)\n"
+    "  --debug-out PATH             PPM path (default ./ngps_acq_debug.ppm)\n"
+    "\n"
+    "General:\n"
+    "  --dry-run 0|1                Do not call TCS (default 0)\n"
+    "  --verbose 0|1                Verbose logs (default 1)\n",
+    argv0
+  );
+}
+
+static void set_defaults(AcqParams* p)
+{
+  memset(p, 0, sizeof(*p));
+  snprintf(p->input, sizeof(p->input), "/tmp/slicecam.fits");
+  p->frame_mode = FRAME_STREAM;
+  snprintf(p->framegrab_out, sizeof(p->framegrab_out), "/tmp/ngps_acq.fits");
+  p->framegrab_use_tmp = 0;
+
+  p->goal_x = 0;
+  p->goal_y = 0;
+  p->pixel_origin = 0;
+
+  p->max_dist_pix = 200.0;
+  p->snr_thresh = 8.0;
+  p->min_adjacent = 4;
+
+  p->filt_sigma_pix = 1.2;
+
+  p->centroid_halfwin = 6;
+  p->centroid_sigma_pix = 2.0;
+  p->centroid_maxiter = 12;
+  p->centroid_eps_pix = 0.01;
+
+  p->extnum = 1;
+  snprintf(p->extname, sizeof(p->extname), "L");
+
+  p->bg_roi_mask = 0;
+  p->search_roi_mask = 0;
+
+  p->loop = 0;
+  p->cadence_sec = 0.0;
+  p->max_samples = 10;
+  p->min_samples = 3;
+  p->prec_arcsec = 0.1;
+  p->goal_arcsec = 0.1;
+  p->max_cycles = 20;
+  p->gain = 0.7;
+  p->adaptive = 0;
+  p->adaptive_faint = 500.0;
+  p->adaptive_faint_goal = 500.0;
+  p->adaptive_bright = 10000.0;
+  p->adaptive_bright_goal = 10000.0;
+
+  p->reject_identical = 1;
+  p->reject_after_move = 2;
+  p->settle_sec = 0.0;
+  p->max_move_arcsec = 10.0;
+  p->continue_on_fail = 0;
+
+  p->dra_use_cosdec = 1;
+  p->tcs_sign = +1;
+
+  p->tcs_set_units = 1;
+
+  p->use_putonslit = 0;
+  p->wait_guiding = 1;
+  p->guiding_poll_sec = 1.0;
+  p->guiding_timeout_sec = 120.0;
+
+  p->debug = 0;
+  snprintf(p->debug_out, sizeof(p->debug_out), "./ngps_acq_debug.ppm");
+
+  p->dry_run = 0;
+  p->verbose = 1;
+}
+
+static int parse_args(int argc, char** argv, AcqParams* p)
+{
+  for (int i = 1; i < argc; i++) {
+    const char* a = argv[i];
+    if (!strcmp(a, "--input") && i+1 < argc) {
+      snprintf(p->input, sizeof(p->input), "%s", argv[++i]);
+    } else if (!strcmp(a, "--goal-x") && i+1 < argc) {
+      p->goal_x = atof(argv[++i]);
+    } else if (!strcmp(a, "--goal-y") && i+1 < argc) {
+      p->goal_y = atof(argv[++i]);
+    } else if (!strcmp(a, "--pixel-origin") && i+1 < argc) {
+      p->pixel_origin = atoi(argv[++i]);
+
+    } else if (!strcmp(a, "--frame-mode") && i+1 < argc) {
+      const char* m = argv[++i];
+      if (!strcasecmp(m, "stream")) p->frame_mode = FRAME_STREAM;
+      else if (!strcasecmp(m, "framegrab")) p->frame_mode = FRAME_FRAMEGRAB;
+      else { acq_logf( "Invalid --frame-mode: %s\n", m); return -1; }
+    } else if (!strcmp(a, "--framegrab-out") && i+1 < argc) {
+      snprintf(p->framegrab_out, sizeof(p->framegrab_out), "%s", argv[++i]);
+
+    } else if (!strcmp(a, "--max-dist") && i+1 < argc) {
+      p->max_dist_pix = atof(argv[++i]);
+    } else if (!strcmp(a, "--snr") && i+1 < argc) {
+      p->snr_thresh = atof(argv[++i]);
+    } else if (!strcmp(a, "--min-adj") && i+1 < argc) {
+      p->min_adjacent = atoi(argv[++i]);
+    } else if (!strcmp(a, "--filt-sigma") && i+1 < argc) {
+      p->filt_sigma_pix = atof(argv[++i]);
+    } else if (!strcmp(a, "--centroid-hw") && i+1 < argc) {
+      p->centroid_halfwin = atoi(argv[++i]);
+    } else if (!strcmp(a, "--centroid-sigma") && i+1 < argc) {
+      p->centroid_sigma_pix = atof(argv[++i]);
+
+    } else if (!strcmp(a, "--extnum") && i+1 < argc) {
+      p->extnum = atoi(argv[++i]);
+    } else if (!strcmp(a, "--extname") && i+1 < argc) {
+      snprintf(p->extname, sizeof(p->extname), "%s", argv[++i]);
+      if (!strcasecmp(p->extname, "none")) p->extname[0] = '\0';
+
+    } else if (!strcmp(a, "--bg-x1") && i+1 < argc) {
+      p->bg_x1 = atol(argv[++i]); p->bg_roi_mask |= ROI_X1_SET;
+    } else if (!strcmp(a, "--bg-x2") && i+1 < argc) {
+      p->bg_x2 = atol(argv[++i]); p->bg_roi_mask |= ROI_X2_SET;
+    } else if (!strcmp(a, "--bg-y1") && i+1 < argc) {
+      p->bg_y1 = atol(argv[++i]); p->bg_roi_mask |= ROI_Y1_SET;
+    } else if (!strcmp(a, "--bg-y2") && i+1 < argc) {
+      p->bg_y2 = atol(argv[++i]); p->bg_roi_mask |= ROI_Y2_SET;
+
+    } else if (!strcmp(a, "--search-x1") && i+1 < argc) {
+      p->search_x1 = atol(argv[++i]); p->search_roi_mask |= ROI_X1_SET;
+    } else if (!strcmp(a, "--search-x2") && i+1 < argc) {
+      p->search_x2 = atol(argv[++i]); p->search_roi_mask |= ROI_X2_SET;
+    } else if (!strcmp(a, "--search-y1") && i+1 < argc) {
+      p->search_y1 = atol(argv[++i]); p->search_roi_mask |= ROI_Y1_SET;
+    } else if (!strcmp(a, "--search-y2") && i+1 < argc) {
+      p->search_y2 = atol(argv[++i]); p->search_roi_mask |= ROI_Y2_SET;
+
+    } else if (!strcmp(a, "--loop") && i+1 < argc) {
+      p->loop = atoi(argv[++i]);
+    } else if (!strcmp(a, "--cadence-sec") && i+1 < argc) {
+      p->cadence_sec = atof(argv[++i]);
+    } else if (!strcmp(a, "--max-samples") && i+1 < argc) {
+      p->max_samples = atoi(argv[++i]);
+    } else if (!strcmp(a, "--min-samples") && i+1 < argc) {
+      p->min_samples = atoi(argv[++i]);
+    } else if (!strcmp(a, "--prec-arcsec") && i+1 < argc) {
+      p->prec_arcsec = atof(argv[++i]);
+    } else if (!strcmp(a, "--goal-arcsec") && i+1 < argc) {
+      p->goal_arcsec = atof(argv[++i]);
+    } else if (!strcmp(a, "--max-cycles") && i+1 < argc) {
+      p->max_cycles = atoi(argv[++i]);
+    } else if (!strcmp(a, "--gain") && i+1 < argc) {
+      p->gain = atof(argv[++i]);
+    } else if (!strcmp(a, "--adaptive") && i+1 < argc) {
+      p->adaptive = atoi(argv[++i]);
+    } else if (!strcmp(a, "--adaptive-faint") && i+1 < argc) {
+      p->adaptive_faint = atof(argv[++i]);
+    } else if (!strcmp(a, "--adaptive-faint-goal") && i+1 < argc) {
+      p->adaptive_faint_goal = atof(argv[++i]);
+    } else if (!strcmp(a, "--adaptive-bright") && i+1 < argc) {
+      p->adaptive_bright = atof(argv[++i]);
+    } else if (!strcmp(a, "--adaptive-bright-goal") && i+1 < argc) {
+      p->adaptive_bright_goal = atof(argv[++i]);
+
+    } else if (!strcmp(a, "--reject-identical") && i+1 < argc) {
+      p->reject_identical = atoi(argv[++i]);
+    } else if (!strcmp(a, "--reject-after-move") && i+1 < argc) {
+      p->reject_after_move = atoi(argv[++i]);
+    } else if (!strcmp(a, "--settle-sec") && i+1 < argc) {
+      p->settle_sec = atof(argv[++i]);
+    } else if (!strcmp(a, "--max-move-arcsec") && i+1 < argc) {
+      p->max_move_arcsec = atof(argv[++i]);
+    } else if (!strcmp(a, "--continue-on-fail") && i+1 < argc) {
+      p->continue_on_fail = atoi(argv[++i]);
+
+    } else if (!strcmp(a, "--dra-use-cosdec") && i+1 < argc) {
+      p->dra_use_cosdec = atoi(argv[++i]);
+    } else if (!strcmp(a, "--tcs-sign") && i+1 < argc) {
+      p->tcs_sign = atoi(argv[++i]);
+      if (!(p->tcs_sign == 1 || p->tcs_sign == -1)) { acq_logf( "--tcs-sign must be +1 or -1\n"); return -1; }
+    } else if (!strcmp(a, "--tcs-set-units") && i+1 < argc) {
+      p->tcs_set_units = atoi(argv[++i]);
+
+    } else if (!strcmp(a, "--use-putonslit") && i+1 < argc) {
+      p->use_putonslit = atoi(argv[++i]);
+
+    } else if (!strcmp(a, "--wait-guiding") && i+1 < argc) {
+      p->wait_guiding = atoi(argv[++i]);
+    } else if (!strcmp(a, "--guiding-poll-sec") && i+1 < argc) {
+      p->guiding_poll_sec = atof(argv[++i]);
+    } else if (!strcmp(a, "--guiding-timeout-sec") && i+1 < argc) {
+      p->guiding_timeout_sec = atof(argv[++i]);
+
+    } else if (!strcmp(a, "--debug") && i+1 < argc) {
+      p->debug = atoi(argv[++i]);
+    } else if (!strcmp(a, "--debug-out") && i+1 < argc) {
+      snprintf(p->debug_out, sizeof(p->debug_out), "%s", argv[++i]);
+
+    } else if (!strcmp(a, "--dry-run") && i+1 < argc) {
+      p->dry_run = atoi(argv[++i]);
+    } else if (!strcmp(a, "--verbose") && i+1 < argc) {
+      p->verbose = atoi(argv[++i]);
+
+    } else if (!strcmp(a, "--help") || !strcmp(a, "-h")) {
+      return 0;
+    } else {
+      acq_logf( "Unknown/invalid arg: %s\n", a);
+      return -1;
+    }
+  }
+
+  if (!(p->pixel_origin == 0 || p->pixel_origin == 1)) {
+    acq_logf( "--pixel-origin must be 0 or 1\n");
+    return -1;
+  }
+  if (!isfinite(p->goal_x) || !isfinite(p->goal_y)) {
+    acq_logf( "You must provide --goal-x and --goal-y\n");
+    return -1;
+  }
+  if (p->max_samples < 1) p->max_samples = 1;
+  if (p->min_samples < 1) p->min_samples = 1;
+  if (p->min_samples > p->max_samples) p->min_samples = p->max_samples;
+  if (p->gain < 0) p->gain = 0;
+  if (p->gain > 1.5) p->gain = 1.5;
+  if (!(p->adaptive == 0 || p->adaptive == 1)) {
+    acq_logf( "--adaptive must be 0 or 1\n");
+    return -1;
+  }
+  if (!isfinite(p->adaptive_faint) || p->adaptive_faint <= 0) {
+    acq_logf( "--adaptive-faint must be > 0\n");
+    return -1;
+  }
+  if (!isfinite(p->adaptive_bright) || p->adaptive_bright <= p->adaptive_faint) {
+    acq_logf( "--adaptive-bright must be > --adaptive-faint\n");
+    return -1;
+  }
+  if (!isfinite(p->adaptive_faint_goal) || p->adaptive_faint_goal <= 0) {
+    acq_logf( "--adaptive-faint-goal must be > 0\n");
+    return -1;
+  }
+  if (!isfinite(p->adaptive_bright_goal) || p->adaptive_bright_goal <= 0) {
+    acq_logf( "--adaptive-bright-goal must be > 0\n");
+    return -1;
+  }
+  if (p->max_move_arcsec <= 0) p->max_move_arcsec = 10.0;
+  if (p->reject_after_move < 0) p->reject_after_move = 0;
+  if (p->cadence_sec < 0) p->cadence_sec = 0;
+  if (p->filt_sigma_pix <= 0) p->filt_sigma_pix = 1.2;
+  if (p->centroid_sigma_pix <= 0) p->centroid_sigma_pix = 2.0;
+  if (p->centroid_halfwin < 2) p->centroid_halfwin = 2;
+  if (p->guiding_poll_sec <= 0) p->guiding_poll_sec = 1.0;
+  if (p->guiding_timeout_sec < 0) p->guiding_timeout_sec = 0;
+
+  if (p->use_putonslit) {
+    // putonslit computes PT internally; no need to set native dra/ddec units.
+    p->tcs_set_units = 0;
+  }
+
+  return 1;
+}
+
+// --- One-shot processing ---
+static int process_once(const AcqParams* p, FrameState* fs)
+{
+  float* img = NULL;
+  long nx=0, ny=0;
+  char* header = NULL;
+  int nkeys = 0;
+  double exptime_sec = 1.0;
+
+  int rc = acquire_next_frame(p, fs, p->cadence_sec, &img, &nx, &ny, &header, &nkeys, &exptime_sec);
+  if (rc) {
+    if (img) free(img);
+    if (header) free(header);
+    return 4;
+  }
+
+  (void)exptime_sec;
+
+  // signature for rejecting identical frames
+  if (p->reject_identical) {
+    long sx1,sx2,sy1,sy2;
+    compute_roi_0based(nx, ny, p->pixel_origin,
+                       p->bg_roi_mask, p->bg_x1, p->bg_x2, p->bg_y1, p->bg_y2,
+                       &sx1,&sx2,&sy1,&sy2);
+    uint64_t sig = image_signature_subsample(img, nx, ny, sx1,sx2,sy1,sy2);
+    if (fs->have_sig && sig == fs->sig) {
+      if (p->verbose) acq_logf( "Duplicate frame signature (reject).\n");
+      free(img);
+      if (header) free(header);
+      return 2;
+    }
+    fs->sig = sig;
+    fs->have_sig = 1;
+  }
+
+  FrameResult fr = solve_frame(img, nx, ny, header, nkeys, p);
+
+  if (p->debug) {
+    (void)write_debug_ppm(p->debug_out, img, nx,
+                          fr.det.rx1, fr.det.rx2, fr.det.ry1, fr.det.ry2,
+                          fr.det.bkg, fr.det.sigma, p->snr_thresh,
+                          &fr.det, p);
+  }
+
+  free(img);
+  if (header) free(header);
+
+  if (!fr.ok) {
+    if (p->verbose) acq_logf( "No valid solution (star/WCS/quality).\n");
+    return 2;
+  }
+
+  if (p->verbose) {
+    acq_logf( "Centroid=(%.3f,%.3f) dx=%.3f dy=%.3f pix  SNR_ap=%.2f\n",
+            fr.det.cx, fr.det.cy, fr.dx_pix, fr.dy_pix, fr.det.snr_ap);
+    if (p->adaptive) {
+      acq_logf( "Source metric (top10%% mean count): %.1f\n", fr.det.src_top10_mean);
+    }
+    acq_logf( "Command offsets (arcsec): dra=%.3f ddec=%.3f  r=%.3f\n",
+            fr.dra_cmd_arcsec, fr.ddec_cmd_arcsec, fr.r_cmd_arcsec);
+  }
+
+  // Machine-readable line
+  printf("NGPS_ACQ_RESULT ok=1 cx=%.6f cy=%.6f dra_arcsec=%.6f ddec_arcsec=%.6f r_arcsec=%.6f snr_ap=%.3f\n",
+         fr.det.cx, fr.det.cy, fr.dra_cmd_arcsec, fr.ddec_cmd_arcsec, fr.r_cmd_arcsec, fr.det.snr_ap);
+
+  // Safety: do not move without stats in loop mode; in one-shot we do a single move only if --loop=0
+  if (!p->loop) {
+    if (fr.r_cmd_arcsec > p->max_move_arcsec) {
+      acq_logf( "REFUSE MOVE: |offset|=%.3f"" exceeds --max-move-arcsec=%.3f\n", fr.r_cmd_arcsec, p->max_move_arcsec);
+      return 3;
+    }
+
+    double dra = p->gain * fr.dra_cmd_arcsec;
+    double ddec = p->gain * fr.ddec_cmd_arcsec;
+
+    if (p->use_putonslit) {
+      if (!fr.wcs_ok) {
+        acq_logf( "REFUSE MOVE: WCS not available for putonslit\n");
+        return 3;
+      }
+      double cross_ra=0.0, cross_dec=0.0;
+      slit_cross_from_offsets(p, fr.ra_goal_deg, fr.dec_goal_deg, dra, ddec, &cross_ra, &cross_dec);
+      (void)scam_putonslit_deg(fr.ra_goal_deg, fr.dec_goal_deg, cross_ra, cross_dec, p->dry_run, p->verbose);
+      (void)wait_for_guiding(p);
+    } else {
+      (void)tcs_move_arcsec(dra, ddec, p->dry_run, p->verbose);
+    }
+  }
+
+  return 0;
+}
+
+// --- Closed-loop acquisition ---
+static int run_loop(const AcqParams* p)
+{
+  FrameState fs;
+  memset(&fs, 0, sizeof(fs));
+  fs.t_accept.tv_sec = 0;
+  fs.t_accept.tv_nsec = 0;
+
+  if (!p->use_putonslit && p->tcs_set_units) (void)tcs_set_native_units(p->dry_run, p->verbose);
+
+  int skip_after_move = 0;
+  AdaptiveRuntime adaptive_rt;
+  memset(&adaptive_rt, 0, sizeof(adaptive_rt));
+  adaptive_rt.mode = ADAPT_MODE_BASELINE;
+  double initial_metric_exptime_sec = 1.0;
+  int have_initial_metric_exptime = 0;
+  int initial_metric_scaled_once = 0;
+
+  for (int cycle = 1; cycle <= p->max_cycles && !stop_requested(); cycle++) {
+    if (p->verbose) acq_logf( "\n=== Cycle %d/%d ===\n", cycle, p->max_cycles);
+
+    AdaptiveCycleConfig cycle_cfg;
+    adaptive_build_cycle_config(p, &adaptive_rt, ADAPT_MODE_BASELINE, 0.0, &cycle_cfg);
+    if (p->adaptive) {
+      double metric_cfg = adaptive_rt.have_metric ? adaptive_rt.metric_ewma : 0.0;
+      if ( !initial_metric_scaled_once &&
+           adaptive_rt.have_metric &&
+           adaptive_rt.mode != ADAPT_MODE_BASELINE &&
+           have_initial_metric_exptime &&
+           initial_metric_exptime_sec > 0.0 ) {
+        metric_cfg /= initial_metric_exptime_sec;
+        initial_metric_scaled_once = 1;
+        if ( p->verbose ) {
+          acq_logf( "Adaptive one-shot metric scaling: metric/EXPTIME using initial EXPTIME=%.3fs\n",
+                    initial_metric_exptime_sec );
+        }
+      }
+      adaptive_build_cycle_config(p, &adaptive_rt, adaptive_rt.mode, metric_cfg, &cycle_cfg);
+      (void)adaptive_apply_camera(p, &adaptive_rt, &cycle_cfg);
+      if (p->verbose) {
+        if (adaptive_rt.have_metric) {
+          acq_logf(
+                  "Adaptive mode=%s ewma=%.1f exp=%.2fs avg=%d cadence=%.2fs reject_after_move=%d prec=%.3f\" goal=%.3f\"\n",
+                  adaptive_mode_name(adaptive_rt.mode), adaptive_rt.metric_ewma,
+                  cycle_cfg.exptime_sec, cycle_cfg.avgframes,
+                  cycle_cfg.cadence_sec, cycle_cfg.reject_after_move,
+                  cycle_cfg.prec_arcsec, cycle_cfg.goal_arcsec);
+        } else {
+          acq_logf(
+                  "Adaptive mode=%s exp=%.2fs avg=%d cadence=%.2fs reject_after_move=%d prec=%.3f\" goal=%.3f\"\n",
+                  adaptive_mode_name(adaptive_rt.mode), cycle_cfg.exptime_sec, cycle_cfg.avgframes,
+                  cycle_cfg.cadence_sec, cycle_cfg.reject_after_move,
+                  cycle_cfg.prec_arcsec, cycle_cfg.goal_arcsec);
+        }
+      }
+    }
+
+    double runtime_cadence_sec = cycle_cfg.cadence_sec;
+    int runtime_reject_after_move = cycle_cfg.reject_after_move;
+    double runtime_prec_arcsec = cycle_cfg.prec_arcsec;
+    double runtime_goal_arcsec = cycle_cfg.goal_arcsec;
+
+    double dra_samp[p->max_samples];
+    double ddec_samp[p->max_samples];
+    double metric_samp[p->max_samples];
+    int n = 0;
+
+    double slit_ra_deg = 0.0, slit_dec_deg = 0.0;
+    int have_slit = 0;
+
+    int attempts = 0;
+    int max_attempts = p->max_samples * 10;
+    int invalid_solution_total = 0;
+    int faint_rescue_steps = 0;
+
+    while (n < p->max_samples && attempts < max_attempts && !stop_requested()) {
+      attempts++;
+
+      float* img = NULL;
+      long nx=0, ny=0;
+      char* header = NULL;
+      int nkeys = 0;
+      double exptime_sec = 1.0;
+
+      int rc = acquire_next_frame(p, &fs, runtime_cadence_sec, &img, &nx, &ny, &header, &nkeys, &exptime_sec);
+      if (rc) {
+        if (img) free(img);
+        if (header) free(header);
+        acq_logf( "WARNING: failed to acquire frame (rc=%d)\n", rc);
+        sleep_seconds(0.1);
+        continue;
+      }
+
+      // signature-based duplicate reject (compute on stats ROI)
+      if (p->reject_identical) {
+        long sx1,sx2,sy1,sy2;
+        compute_roi_0based(nx, ny, p->pixel_origin,
+                           p->bg_roi_mask, p->bg_x1, p->bg_x2, p->bg_y1, p->bg_y2,
+                           &sx1,&sx2,&sy1,&sy2);
+        uint64_t sig = image_signature_subsample(img, nx, ny, sx1,sx2,sy1,sy2);
+        if (fs.have_sig && sig == fs.sig) {
+          if (p->verbose) acq_logf( "Reject: identical frame signature\n");
+          free(img);
+          if (header) free(header);
+          continue;
+        }
+        fs.sig = sig;
+        fs.have_sig = 1;
+      }
+
+      if (skip_after_move > 0) {
+        skip_after_move--;
+        if (p->verbose) acq_logf( "Reject: post-move frame (%d remaining)\n", skip_after_move);
+        free(img);
+        if (header) free(header);
+        continue;
+      }
+
+      FrameResult fr = solve_frame(img, nx, ny, header, nkeys, p);
+
+      if (p->debug) {
+        (void)write_debug_ppm(p->debug_out, img, nx,
+                              fr.det.rx1, fr.det.rx2, fr.det.ry1, fr.det.ry2,
+                              fr.det.bkg, fr.det.sigma, p->snr_thresh,
+                              &fr.det, p);
+      }
+
+      free(img);
+      if (header) free(header);
+
+      if (!fr.ok) {
+        invalid_solution_total++;
+        if (p->adaptive && invalid_solution_total >= (6 * (faint_rescue_steps + 1))) {
+          double cur_exp = adaptive_rt.have_last_camera ? adaptive_rt.last_exptime_sec : exptime_sec;
+          int cur_avg = adaptive_rt.have_last_camera ? adaptive_rt.last_avgframes : 1;
+          if (!isfinite(cur_exp) || cur_exp <= 0.0) cur_exp = 1.0;
+          if (cur_avg < 1) cur_avg = 1;
+          if (cur_avg > 5) cur_avg = 5;
+
+          static const double rescue_exptime_ladder[] = { 0.1, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 15.0 };
+          double target_exp = cur_exp;
+          for (size_t i = 0; i < sizeof(rescue_exptime_ladder)/sizeof(rescue_exptime_ladder[0]); i++) {
+            if (rescue_exptime_ladder[i] > cur_exp + 1e-6) {
+              target_exp = rescue_exptime_ladder[i];
+              break;
+            }
+          }
+
+          if (target_exp > cur_exp + 1e-6) {
+            if (p->verbose) {
+              acq_logf( "Adaptive faint rescue: %d invalid frames; exptime %.3fs -> %.3fs\n",
+                        invalid_solution_total, cur_exp, target_exp);
+            }
+            (void)scam_set_exptime(target_exp, p->dry_run, p->verbose);
+            adaptive_rt.have_last_camera = 1;
+            adaptive_rt.last_exptime_sec = target_exp;
+            adaptive_rt.last_avgframes = cur_avg;
+            runtime_cadence_sec = fmax(runtime_cadence_sec, target_exp * (double)cur_avg + 0.20);
+          }
+          else {
+            if (p->verbose) {
+              acq_logf( "Adaptive faint rescue: %d invalid frames; exptime cannot increase further (cur=%.3fs)\n",
+                        invalid_solution_total, cur_exp);
+            }
+          }
+
+          faint_rescue_steps++;
+        }
+        if (p->verbose) acq_logf( "Reject: no valid solution (SNR/WCS/star).\n");
+        continue;
+      }
+
+      if (fr.r_cmd_arcsec > p->max_move_arcsec) {
+        acq_logf( "Reject: |offset|=%.3f"" exceeds --max-move-arcsec=%.3f\n", fr.r_cmd_arcsec, p->max_move_arcsec);
+        continue;
+      }
+
+      if ( !have_initial_metric_exptime && isfinite(exptime_sec) && exptime_sec > 0.0 ) {
+        initial_metric_exptime_sec = exptime_sec;
+        have_initial_metric_exptime = 1;
+      }
+
+      metric_samp[n] = fr.det.src_top10_mean;
+      dra_samp[n]  = fr.dra_cmd_arcsec;
+      ddec_samp[n] = fr.ddec_cmd_arcsec;
+      slit_ra_deg  = fr.ra_goal_deg;
+      slit_dec_deg = fr.dec_goal_deg;
+      have_slit = 1;
+      n++;
+
+      // Compute robust stats on the fly
+      double dra_tmp[p->max_samples];
+      double ddec_tmp[p->max_samples];
+      for (int i = 0; i < n; i++) { dra_tmp[i]=dra_samp[i]; ddec_tmp[i]=ddec_samp[i]; }
+      double med_dra = median_of_doubles(dra_tmp, n);
+      double med_ddec = median_of_doubles(ddec_tmp, n);
+      double sig_dra = mad_sigma_of_doubles(dra_samp, n, med_dra);
+      double sig_ddec = mad_sigma_of_doubles(ddec_samp, n, med_ddec);
+      double rmed = hypot(med_dra, med_ddec);
+
+      if (p->verbose) {
+        if (p->adaptive) {
+          acq_logf( "Sample %d/%d: dra=%.3f"" ddec=%.3f"" |med|=%.3f""  scatter(MAD)=(%.3f,%.3f)"" metric=%.1f mode=%s\n",
+                  n, p->max_samples, dra_samp[n-1], ddec_samp[n-1], rmed, sig_dra, sig_ddec,
+                  fr.det.src_top10_mean, adaptive_mode_name(adaptive_rt.mode));
+        } else {
+          acq_logf( "Sample %d/%d: dra=%.3f"" ddec=%.3f"" |med|=%.3f""  scatter(MAD)=(%.3f,%.3f)""\n",
+                  n, p->max_samples, dra_samp[n-1], ddec_samp[n-1], rmed, sig_dra, sig_ddec);
+        }
+      }
+
+      // If already within goal threshold, finish (no move)
+      if (n >= p->min_samples && rmed <= runtime_goal_arcsec) {
+        if (p->verbose) acq_logf( "Converged: |median offset|=%.3f"" <= %.3f""\n", rmed, runtime_goal_arcsec);
+        return 0;
+      }
+
+      // If centroiding precision is good enough, we can move now
+      if (n >= p->min_samples && sig_dra <= runtime_prec_arcsec && sig_ddec <= runtime_prec_arcsec) {
+        // Issue robust move
+        double cmd_dra = p->gain * med_dra;
+        double cmd_ddec = p->gain * med_ddec;
+
+        if (p->verbose) {
+          acq_logf( "MOVE (robust median): dra=%.3f"" ddec=%.3f""  (gain=%.3f)\n", cmd_dra, cmd_ddec, p->gain);
+        }
+
+        if (p->use_putonslit) {
+          if (!have_slit) {
+            acq_logf( "REFUSE MOVE: missing slit RA/Dec for putonslit\n");
+          } else {
+            double cross_ra=0.0, cross_dec=0.0;
+            slit_cross_from_offsets(p, slit_ra_deg, slit_dec_deg, cmd_dra, cmd_ddec, &cross_ra, &cross_dec);
+            (void)scam_putonslit_deg(slit_ra_deg, slit_dec_deg, cross_ra, cross_dec, p->dry_run, p->verbose);
+            (void)wait_for_guiding(p);
+          }
+        } else {
+          (void)tcs_move_arcsec(cmd_dra, cmd_ddec, p->dry_run, p->verbose);
+        }
+
+        // After move, reject a few new frames to avoid trailed exposures.
+        adaptive_finish_cycle(p, &adaptive_rt, metric_samp, n);
+        if (p->settle_sec > 0) sleep_seconds(p->settle_sec);
+        skip_after_move = runtime_reject_after_move;
+
+        // proceed to next cycle
+        goto next_cycle;
+      }
+    }
+
+    // If we get here, we did not reach required precision.
+    if (n >= p->min_samples) {
+      double dra_tmp[p->max_samples];
+      double ddec_tmp[p->max_samples];
+      for (int i = 0; i < n; i++) { dra_tmp[i]=dra_samp[i]; ddec_tmp[i]=ddec_samp[i]; }
+      double med_dra = median_of_doubles(dra_tmp, n);
+      double med_ddec = median_of_doubles(ddec_tmp, n);
+      double sig_dra = mad_sigma_of_doubles(dra_samp, n, med_dra);
+      double sig_ddec = mad_sigma_of_doubles(ddec_samp, n, med_ddec);
+      double rmed = hypot(med_dra, med_ddec);
+
+      acq_logf( "FAIL: insufficient precision to move safely after %d samples (attempts=%d).\n", n, attempts);
+      acq_logf( "      median(dra,ddec)=(%.3f,%.3f)""  scatter(MAD)=(%.3f,%.3f)""  |med|=%.3f""\n",
+              med_dra, med_ddec, sig_dra, sig_ddec, rmed);
+    } else {
+      acq_logf( "FAIL: too few valid samples (n=%d) after attempts=%d.\n", n, attempts);
+    }
+
+    adaptive_finish_cycle(p, &adaptive_rt, metric_samp, n);
+
+    if (!p->continue_on_fail) return 2;
+
+next_cycle:
+    ;
+  }
+
+  if (stop_requested()) {
+    acq_logf( "Stopped by user request.\n");
+    return 1;
+  }
+
+  acq_logf( "FAILED: reached max cycles (%d) without convergence.\n", p->max_cycles);
+  return 1;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ngps_acq_set_hooks(const ngps_acq_hooks_t* hooks) {
+  if (!hooks) {
+    memset(&g_hooks, 0, sizeof(g_hooks));
+    g_hooks_initialized = 0;
+    return;
+  }
+
+  g_hooks = *hooks;
+  g_hooks_initialized = 1;
+}
+
+void ngps_acq_clear_hooks(void) {
+  memset(&g_hooks, 0, sizeof(g_hooks));
+  g_hooks_initialized = 0;
+}
+
+void ngps_acq_request_stop(int stop_requested_flag) {
+  g_stop = stop_requested_flag ? 1 : 0;
+}
+
+static int ngps_acq_run_internal(int argc, char** argv, int install_signal_handler)
+{
+  g_stop = 0;
+  if (install_signal_handler) signal(SIGINT, on_sigint);
+
+  AcqParams p;
+  set_defaults(&p);
+
+  int pr = parse_args(argc, argv, &p);
+  if (pr <= 0) { usage(argv[0]); return (pr == 0) ? 0 : 4; }
+
+  if (p.verbose) {
+    acq_logf(
+      "NGPS ACQ start:\n"
+      "  mode=%s input=%s framegrab_out=%s\n"
+      "  goal=(%.3f,%.3f) origin=%d max_dist=%.1f snr=%.1f filt_sigma=%.2f\n"
+      "  centroid_hw=%d centroid_sigma=%.2f\n"
+      "  loop=%d cadence=%.2fs max_samples=%d min_samples=%d prec=%.3f\" goal=%.3f\" gain=%.2f\n"
+      "  reject_identical=%d reject_after_move=%d settle=%.2fs max_move=%.2f\"\n"
+      "  use_putonslit=%d wait_guiding=%d guiding_poll=%.2fs guiding_timeout=%.1fs\n"
+      "  tcs_set_units=%d dra_use_cosdec=%d tcs_sign=%d dry_run=%d\n",
+      (p.frame_mode == FRAME_FRAMEGRAB) ? "framegrab" : "stream",
+      p.input, p.framegrab_out,
+      p.goal_x, p.goal_y, p.pixel_origin, p.max_dist_pix, p.snr_thresh, p.filt_sigma_pix,
+      p.centroid_halfwin, p.centroid_sigma_pix,
+      p.loop, p.cadence_sec, p.max_samples, p.min_samples, p.prec_arcsec, p.goal_arcsec, p.gain,
+      p.reject_identical, p.reject_after_move, p.settle_sec, p.max_move_arcsec,
+      p.use_putonslit, p.wait_guiding, p.guiding_poll_sec, p.guiding_timeout_sec,
+      p.tcs_set_units, p.dra_use_cosdec, p.tcs_sign, p.dry_run);
+    if (p.adaptive) {
+      acq_logf( "  adaptive=1 faint-start=%.1f faint-goal=%.1f bright-start=%.1f bright-goal=%.1f\n",
+              p.adaptive_faint, p.adaptive_faint_goal, p.adaptive_bright, p.adaptive_bright_goal);
+    }
+  }
+
+  if (p.loop) {
+    return run_loop(&p);
+  }
+
+  // One-shot: acquire one frame and (optionally) move once.
+  if (p.tcs_set_units) (void)tcs_set_native_units(p.dry_run, p.verbose);
+  FrameState fs;
+  memset(&fs, 0, sizeof(fs));
+  fs.t_accept.tv_sec = 0;
+  fs.t_accept.tv_nsec = 0;
+  return process_once(&p, &fs);
+}
+
+int ngps_acq_run_from_argv(int argc, char** argv) {
+  return ngps_acq_run_internal(argc, argv, 0);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifndef NGPS_ACQ_EMBEDDED
+int main(int argc, char** argv)
+{
+  return ngps_acq_run_internal(argc, argv, 1);
+}
+#endif

--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -9,6 +9,209 @@
  */
 
 #include "slicecam_interface.h"
+#include "ngps_acq_embed.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+
+namespace {
+
+struct AutoacqRunContext {
+  Slicecam::Interface *iface;
+  std::string logfile;
+  std::mutex log_mtx;
+};
+
+std::string trim_copy( std::string value ) {
+  value.erase( value.begin(),
+               std::find_if( value.begin(), value.end(),
+                             [](unsigned char c){ return !std::isspace(c); } ) );
+  rtrim( value );
+  return value;
+}
+
+bool split_shell_words( const std::string &input, std::vector<std::string> &tokens, std::string &error ) {
+  tokens.clear();
+  error.clear();
+
+  std::string current;
+  char quote = '\0';
+  bool escape = false;
+
+  for ( const char ch : input ) {
+    if ( escape ) {
+      current.push_back( ch );
+      escape = false;
+      continue;
+    }
+
+    if ( ch == '\\' ) {
+      escape = true;
+      continue;
+    }
+
+    if ( quote != '\0' ) {
+      if ( ch == quote ) quote = '\0';
+      else current.push_back( ch );
+      continue;
+    }
+
+    if ( ch == '\'' || ch == '"' ) {
+      quote = ch;
+      continue;
+    }
+
+    if ( std::isspace( static_cast<unsigned char>(ch) ) ) {
+      if ( !current.empty() ) {
+        tokens.push_back( current );
+        current.clear();
+      }
+      continue;
+    }
+
+    current.push_back( ch );
+  }
+
+  if ( escape ) {
+    error = "unterminated escape in autoacq args";
+    return false;
+  }
+
+  if ( quote != '\0' ) {
+    error = "unterminated quoted string in autoacq args";
+    return false;
+  }
+
+  if ( !current.empty() ) tokens.push_back( current );
+  return true;
+}
+
+bool is_autoacq_program_token( const std::string &token ) {
+  auto slash = token.find_last_of( "/\\" );
+  std::string base = ( slash == std::string::npos ? token : token.substr( slash + 1 ) );
+  return ( base == "ngps_acq" || base == "ngps_acquire" );
+}
+
+int cb_tcs_set_native_units( void *user, int dry_run, int verbose ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface ) return 1;
+
+  if ( dry_run ) return 0;
+
+  std::string retstring;
+  if ( !ctx->iface->tcsd.client.is_open() && ctx->iface->tcs_init( "", retstring ) != NO_ERROR ) {
+    if ( verbose ) logwrite( "Slicecam::autoacq", "WARNING: unable to initialize tcsd client for autoacq" );
+    return 1;
+  }
+
+  if ( ctx->iface->tcsd.client.command( TCSD_NATIVE + " dra arcsec", retstring ) != NO_ERROR ) return 1;
+  if ( ctx->iface->tcsd.client.command( TCSD_NATIVE + " ddec arcsec", retstring ) != NO_ERROR ) return 1;
+  return 0;
+}
+
+int cb_tcs_move_arcsec( void *user, double dra_arcsec, double ddec_arcsec, int dry_run, int verbose ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface ) return 1;
+
+  if ( dry_run ) return 0;
+
+  std::string retstring;
+  if ( !ctx->iface->tcsd.client.is_open() && ctx->iface->tcs_init( "", retstring ) != NO_ERROR ) {
+    if ( verbose ) logwrite( "Slicecam::autoacq", "WARNING: unable to initialize tcsd client for autoacq move" );
+    return 1;
+  }
+
+  std::ostringstream cmd;
+  cmd << TCSD_NATIVE << " pt "
+      << std::fixed << std::setprecision(3) << dra_arcsec << " "
+      << std::fixed << std::setprecision(3) << ddec_arcsec;
+  return ( ctx->iface->tcsd.client.command( cmd.str(), retstring ) == NO_ERROR ) ? 0 : 1;
+}
+
+int cb_scam_putonslit_deg( void *user,
+                           double slit_ra_deg, double slit_dec_deg,
+                           double cross_ra_deg, double cross_dec_deg,
+                           int dry_run, int /*verbose*/ ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface ) return 1;
+
+  if ( dry_run ) return 0;
+
+  std::ostringstream args;
+  args << std::fixed << std::setprecision(10)
+       << slit_ra_deg << " " << slit_dec_deg << " "
+       << cross_ra_deg << " " << cross_dec_deg;
+
+  std::string retstring;
+  return ( ctx->iface->put_on_slit( args.str(), retstring ) == NO_ERROR ) ? 0 : 1;
+}
+
+int cb_acam_query_state( void *user, char *state, size_t state_sz, int /*verbose*/ ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface || !state || state_sz == 0 ) return 2;
+
+  bool is_guiding = false;
+  if ( ctx->iface->get_acam_guide_state( is_guiding ) != NO_ERROR ) return 1;
+
+  snprintf( state, state_sz, "%s", is_guiding ? "guiding" : "acquiring" );
+  return 0;
+}
+
+int cb_scam_framegrab_one( void *user, const char *outpath, int /*verbose*/ ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface || !outpath || !*outpath ) return 1;
+
+  std::string retstring;
+  std::string args = std::string("one ") + outpath;
+  return ( ctx->iface->framegrab( args, retstring ) == NO_ERROR ) ? 0 : 1;
+}
+
+int cb_scam_set_exptime( void *user, double exptime_sec, int dry_run, int /*verbose*/ ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface ) return 1;
+  if ( dry_run ) return 0;
+
+  std::ostringstream args;
+  args << std::fixed << std::setprecision(3) << exptime_sec;
+
+  std::string retstring;
+  return ( ctx->iface->exptime( args.str(), retstring ) == NO_ERROR ) ? 0 : 1;
+}
+
+int cb_scam_set_avgframes( void *user, int avgframes, int dry_run, int /*verbose*/ ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface ) return 1;
+  if ( dry_run ) return 0;
+
+  if ( avgframes < 1 ) avgframes = 1;
+  std::string retstring;
+  return ( ctx->iface->avg_frames( std::to_string(avgframes), retstring ) == NO_ERROR ) ? 0 : 1;
+}
+
+int cb_is_stop_requested( void *user ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !ctx->iface ) return 1;
+  return ctx->iface->autoacq_stop_requested() ? 1 : 0;
+}
+
+void cb_log_message( void *user, const char *line ) {
+  auto *ctx = static_cast<AutoacqRunContext*>( user );
+  if ( !ctx || !line || !*line ) return;
+
+  if ( !ctx->logfile.empty() ) {
+    std::lock_guard<std::mutex> lock( ctx->log_mtx );
+    std::ofstream logfile( ctx->logfile, std::ios::app );
+    if ( logfile.is_open() ) logfile << line;
+  }
+}
+
+}  // namespace
 
 namespace Slicecam {
 
@@ -1364,6 +1567,16 @@ namespace Slicecam {
         applied++;
       }
 
+      if ( config.param[entry] == "AUTOACQ_ARGS" || config.param[entry] == "AUTOACQ_CMD" ) {
+        this->autoacq_args = trim_copy( config.arg[entry] );
+        message.str(""); message << "SLICECAMD:config:" << config.param[entry] << "=" << this->autoacq_args;
+        logwrite( function, message.str() );
+        if ( config.param[entry] == "AUTOACQ_CMD" ) {
+          logwrite( function, "NOTICE AUTOACQ_CMD is deprecated; use AUTOACQ_ARGS" );
+        }
+        applied++;
+      }
+
       if ( config.param[entry] == "SKYSIM_IMAGE_SIZE" ) {
         try {
           this->camera.set_simsize( std::stoi( config.arg[entry] ) );
@@ -2265,6 +2478,330 @@ namespace Slicecam {
   /***** Slicecam::Interface::dothread_fpoffset *******************************/
 
 
+  /***** Slicecam::Interface::publish_autoacq_state ***************************/
+  /**
+   * @brief      publish auto-acquire state changes for sequencer
+   *
+   */
+  void Interface::publish_autoacq_state( const std::string &state, uint64_t run_id,
+                                         int exit_code, const std::string &message ) {
+    if ( !this->publisher ) return;
+
+    nlohmann::json jmessage_out;
+    jmessage_out["source"] = Slicecam::DAEMON_NAME;
+    jmessage_out["state"] = state;
+    jmessage_out["run_id"] = run_id;
+    jmessage_out["active"] = this->autoacq_running.load(std::memory_order_acquire);
+    jmessage_out["exit_code"] = exit_code;
+    jmessage_out["message"] = message;
+
+    try {
+      this->publisher->publish( jmessage_out, "slicecam_autoacq" );
+    }
+    catch ( const std::exception &e ) {
+      logwrite( "Slicecam::Interface::publish_autoacq_state",
+                "ERROR publishing message: "+std::string(e.what()) );
+    }
+  }
+  /***** Slicecam::Interface::publish_autoacq_state ***************************/
+
+
+  /***** Slicecam::Interface::dothread_autoacq ********************************/
+  /**
+   * @brief      run embedded NGPS auto-acquire logic in a worker thread
+   *
+   */
+  void Interface::dothread_autoacq( std::string args, std::string logfile, uint64_t run_id ) {
+    const std::string function = "Slicecam::Interface::dothread_autoacq";
+
+    std::vector<std::string> tokenized_args;
+    std::string split_error;
+    if ( !split_shell_words( trim_copy(args), tokenized_args, split_error ) ) {
+      const std::string final_message = "invalid autoacq args: " + split_error;
+      {
+        std::lock_guard<std::mutex> lock( this->autoacq_state_mtx );
+        this->autoacq_state = "failed";
+        this->autoacq_message = final_message;
+        this->autoacq_exit_code = 4;
+      }
+      this->autoacq_running.store( false, std::memory_order_release );
+      this->autoacq_abort_requested.store( false, std::memory_order_release );
+      logwrite( function, final_message );
+      this->publish_autoacq_state( "failed", run_id, 4, final_message );
+      return;
+    }
+
+    while ( !tokenized_args.empty() && is_autoacq_program_token( tokenized_args.front() ) ) {
+      tokenized_args.erase( tokenized_args.begin() );
+    }
+
+    if ( tokenized_args.empty() ) {
+      std::vector<std::string> default_tokens;
+      std::string default_error;
+      if ( !split_shell_words( trim_copy(this->autoacq_args), default_tokens, default_error ) ) {
+        const std::string final_message = "invalid configured AUTOACQ_ARGS: " + default_error;
+        {
+          std::lock_guard<std::mutex> lock( this->autoacq_state_mtx );
+          this->autoacq_state = "failed";
+          this->autoacq_message = final_message;
+          this->autoacq_exit_code = 4;
+        }
+        this->autoacq_running.store( false, std::memory_order_release );
+        this->autoacq_abort_requested.store( false, std::memory_order_release );
+        logwrite( function, final_message );
+        this->publish_autoacq_state( "failed", run_id, 4, final_message );
+        return;
+      }
+
+      while ( !default_tokens.empty() && is_autoacq_program_token( default_tokens.front() ) ) {
+        default_tokens.erase( default_tokens.begin() );
+      }
+      tokenized_args = std::move( default_tokens );
+    }
+
+    if ( tokenized_args.empty() ) {
+      const std::string final_message = "AUTOACQ_ARGS is empty";
+      {
+        std::lock_guard<std::mutex> lock( this->autoacq_state_mtx );
+        this->autoacq_state = "failed";
+        this->autoacq_message = final_message;
+        this->autoacq_exit_code = 4;
+      }
+      this->autoacq_running.store( false, std::memory_order_release );
+      this->autoacq_abort_requested.store( false, std::memory_order_release );
+      logwrite( function, final_message );
+      this->publish_autoacq_state( "failed", run_id, 4, final_message );
+      return;
+    }
+
+    std::vector<std::string> argv_storage;
+    argv_storage.reserve( tokenized_args.size() + 1 );
+    argv_storage.emplace_back( "ngps_acq" );
+    for ( const auto &token : tokenized_args ) argv_storage.push_back( token );
+
+    std::vector<char*> argv;
+    argv.reserve( argv_storage.size() );
+    for ( auto &token : argv_storage ) argv.push_back( const_cast<char*>( token.c_str() ) );
+
+    AutoacqRunContext ctx;
+    ctx.iface = this;
+    ctx.logfile = logfile;
+
+    if ( !ctx.logfile.empty() ) {
+      try {
+        auto parent = std::filesystem::path( ctx.logfile ).parent_path();
+        if ( !parent.empty() ) std::filesystem::create_directories( parent );
+      }
+      catch ( const std::exception &e ) {
+        logwrite( function, "WARNING: unable to create autoacq log path: " + std::string(e.what()) );
+      }
+      std::ofstream out( ctx.logfile, std::ios::app );
+      if ( out.is_open() ) {
+        out << "=== SLICECAMD AUTOACQ run_id=" << run_id << " start ===" << std::endl;
+      }
+    }
+
+    ngps_acq_hooks_t hooks {};
+    hooks.user = &ctx;
+    hooks.tcs_set_native_units = cb_tcs_set_native_units;
+    hooks.tcs_move_arcsec = cb_tcs_move_arcsec;
+    hooks.scam_putonslit_deg = cb_scam_putonslit_deg;
+    hooks.acam_query_state = cb_acam_query_state;
+    hooks.scam_framegrab_one = cb_scam_framegrab_one;
+    hooks.scam_set_exptime = cb_scam_set_exptime;
+    hooks.scam_set_avgframes = cb_scam_set_avgframes;
+    hooks.is_stop_requested = cb_is_stop_requested;
+    hooks.log_message = cb_log_message;
+
+    ngps_acq_set_hooks( &hooks );
+    ngps_acq_request_stop( 0 );
+    const int exit_code = ngps_acq_run_from_argv( static_cast<int>(argv.size()), argv.data() );
+    ngps_acq_request_stop( 0 );
+    ngps_acq_clear_hooks();
+
+    std::string final_state;
+    std::string final_message;
+    if ( this->autoacq_abort_requested.load(std::memory_order_acquire) ) {
+      final_state = "aborted";
+      final_message = "autoacq aborted";
+    }
+    else if ( exit_code == 0 ) {
+      final_state = "success";
+      final_message = "autoacq complete";
+    }
+    else {
+      final_state = "failed";
+      final_message = "autoacq failed with exit code " + std::to_string(exit_code);
+    }
+
+    {
+      std::lock_guard<std::mutex> lock( this->autoacq_state_mtx );
+      this->autoacq_state = final_state;
+      this->autoacq_message = final_message;
+      this->autoacq_exit_code = exit_code;
+    }
+
+    this->autoacq_running.store( false, std::memory_order_release );
+    this->autoacq_abort_requested.store( false, std::memory_order_release );
+
+    if ( !ctx.logfile.empty() ) {
+      std::ofstream out( ctx.logfile, std::ios::app );
+      if ( out.is_open() ) {
+        out << "=== SLICECAMD AUTOACQ run_id=" << run_id
+            << " state=" << final_state
+            << " exit_code=" << exit_code
+            << " ===" << std::endl;
+      }
+    }
+
+    logwrite( function, final_message );
+    this->publish_autoacq_state( final_state, run_id, exit_code, final_message );
+  }
+  /***** Slicecam::Interface::dothread_autoacq ********************************/
+
+
+  /***** Slicecam::Interface::autoacq *****************************************/
+  /**
+   * @brief      controls in-process auto-acquire logic
+   *
+   */
+  long Interface::autoacq( std::string args, std::string &retstring ) {
+    const std::string function = "Slicecam::Interface::autoacq";
+    std::stringstream message;
+    std::vector<std::string> tokens;
+    Tokenize( args, tokens, " " );
+
+    std::string action = tokens.empty() ? "status" : tokens.at(0);
+
+    if ( action == "?" || action == "help" ) {
+      retstring = SLICECAMD_AUTOACQ;
+      retstring.append( " [ start [--log-file <path>] [<args>] | stop | status ]\n" );
+      retstring.append( "  Run or monitor in-process auto-acquire logic.\n" );
+      retstring.append( "  <args> override AUTOACQ_ARGS for this run.\n" );
+      retstring.append( "  Status returns state, run id, active state, and last exit code.\n" );
+      return HELP;
+    }
+
+    if ( action == "status" ) {
+      std::string state;
+      std::string state_message;
+      int exit_code;
+      {
+        std::lock_guard<std::mutex> lock( this->autoacq_state_mtx );
+        state = this->autoacq_state;
+        state_message = this->autoacq_message;
+        exit_code = this->autoacq_exit_code;
+      }
+      retstring = "state="+state
+                + " run_id=" + std::to_string(this->autoacq_run_counter.load(std::memory_order_acquire))
+                + " active=" + std::string(this->autoacq_running.load(std::memory_order_acquire) ? "true" : "false")
+                + " exit_code=" + std::to_string(exit_code);
+      if ( !state_message.empty() ) retstring += " message=\"" + state_message + "\"";
+      return NO_ERROR;
+    }
+
+    if ( action == "stop" ) {
+      if ( !this->autoacq_running.load(std::memory_order_acquire) ) {
+        retstring = "not_running";
+        return NO_ERROR;
+      }
+
+      this->autoacq_abort_requested.store( true, std::memory_order_release );
+      ngps_acq_request_stop( 1 );
+      retstring = "stopping run_id=" + std::to_string(this->autoacq_run_counter.load(std::memory_order_acquire));
+      return NO_ERROR;
+    }
+
+    if ( action == "start" ) {
+      if ( this->autoacq_running.load(std::memory_order_acquire) ) {
+        retstring = "autoacq already running";
+        return BUSY;
+      }
+
+      std::string effective_args = trim_copy( this->autoacq_args );
+      std::string logfile;
+
+      auto pos = args.find_first_of( " \t" );
+      if ( pos != std::string::npos ) {
+        std::string trailing = trim_copy( args.substr( pos + 1 ) );
+        if ( !trailing.empty() ) {
+          std::vector<std::string> trailing_tokens;
+          std::string split_error;
+          if ( !split_shell_words( trailing, trailing_tokens, split_error ) ) {
+            retstring = "invalid autoacq args: " + split_error;
+            return ERROR;
+          }
+
+          std::vector<std::string> filtered_tokens;
+          for ( size_t i = 0; i < trailing_tokens.size(); ) {
+            if ( trailing_tokens.at(i) == "--log-file" ) {
+              if ( (i+1) >= trailing_tokens.size() ) {
+                retstring = "missing value for --log-file";
+                return ERROR;
+              }
+              logfile = trailing_tokens.at(i+1);
+              i += 2;
+              continue;
+            }
+            filtered_tokens.push_back( trailing_tokens.at(i) );
+            i++;
+          }
+
+          if ( !filtered_tokens.empty() ) {
+            std::ostringstream rebuilt;
+            for ( size_t i = 0; i < filtered_tokens.size(); i++ ) {
+              if ( i > 0 ) rebuilt << " ";
+              rebuilt << filtered_tokens.at(i);
+            }
+            effective_args = rebuilt.str();
+          }
+        }
+      }
+
+      std::vector<std::string> check_tokens;
+      std::string split_error;
+      if ( !split_shell_words( effective_args, check_tokens, split_error ) ) {
+        retstring = "invalid AUTOACQ_ARGS: " + split_error;
+        return ERROR;
+      }
+      if ( check_tokens.size() == 1 && is_autoacq_program_token( check_tokens.front() ) ) {
+        effective_args = trim_copy( this->autoacq_args );
+      }
+
+      if ( trim_copy(effective_args).empty() ) {
+        logwrite( function, "ERROR AUTOACQ_ARGS is empty" );
+        retstring = "AUTOACQ_ARGS is empty";
+        return ERROR;
+      }
+
+      uint64_t run_id = this->autoacq_run_counter.fetch_add( 1, std::memory_order_acq_rel ) + 1;
+      {
+        std::lock_guard<std::mutex> lock( this->autoacq_state_mtx );
+        this->autoacq_state = "running";
+        this->autoacq_message = "autoacq started";
+        this->autoacq_exit_code = 0;
+      }
+      this->autoacq_abort_requested.store( false, std::memory_order_release );
+      this->autoacq_running.store( true, std::memory_order_release );
+      ngps_acq_request_stop( 0 );
+
+      message.str(""); message << "NOTICE: starting autoacq run_id=" << run_id << " args=\"" << effective_args << "\"";
+      if ( !logfile.empty() ) message << " log=" << logfile;
+      logwrite( function, message.str() );
+
+      this->publish_autoacq_state( "running", run_id, 0, "autoacq started" );
+      std::thread( &Slicecam::Interface::dothread_autoacq, this, effective_args, logfile, run_id ).detach();
+
+      retstring = "started run_id=" + std::to_string(run_id);
+      return NO_ERROR;
+    }
+
+    retstring = "invalid_argument";
+    return ERROR;
+  }
+  /***** Slicecam::Interface::autoacq *****************************************/
+
+
   /***** Slicecam::Interface::get_acam_guide_state ****************************/
   /**
    * @brief      asks if ACAM is guiding
@@ -2414,8 +2951,18 @@ namespace Slicecam {
         return ERROR;
       }
     }
-    else
-    if ( !is_guiding && this->tcs_online.load(std::memory_order_acquire) && this->tcsd.client.is_open() ) {
+    else if ( !is_guiding ) {
+      // Ensure tcsd/tcs connection is available before issuing PT.
+      //
+      if ( !this->tcs_online.load(std::memory_order_acquire) || !this->tcsd.client.is_open() ) {
+        std::string tcsret;
+        if ( this->tcs_init( "", tcsret ) != NO_ERROR || !this->tcsd.client.is_open() ) {
+          logwrite( function, "ERROR not connected to tcsd" );
+          retstring="tcs_not_connected";
+          return ERROR;
+        }
+      }
+
       // offsets are in degrees, convert to arcsec (required for PT command)
       //
       ra_off  *= 3600.;
@@ -2428,11 +2975,6 @@ namespace Slicecam {
         retstring="tcs_error";
         return ERROR;
       }
-    }
-    else if ( !is_guiding ) {
-      logwrite( function, "ERROR not connected to tcsd" );
-      retstring="tcs_not_connected";
-      return ERROR;
     }
 
     message.str(""); message << "requested offsets dRA=" << ra_off << " dDEC=" << dec_off << " arcsec";

--- a/slicecamd/slicecam_server.cpp
+++ b/slicecamd/slicecam_server.cpp
@@ -585,6 +585,10 @@ namespace Slicecam {
                       ret = this->interface.saveframes( args, retstring );
       }
       else
+      if ( cmd == SLICECAMD_AUTOACQ ) {
+                      ret = this->interface.autoacq( args, retstring );
+      }
+      else
       if ( cmd == SLICECAMD_PUTONSLIT ) {
                       ret = this->interface.put_on_slit( args, retstring );
       }

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -63,6 +63,31 @@ target_link_libraries( listener PRIVATE utilities )
 
 # -- ZeroMQ --------------------------------------------------------------------
 #
-find_library( ZMQPP_LIB zmqpp NAMES libzmqpp PATHS /usr/local/lib )
-find_library( ZMQ_LIB zmq NAMES libzmq PATHS /usr/local/lib )
+find_library( ZMQPP_LIB NAMES zmqpp libzmqpp
+              PATHS /usr/local/lib /opt/homebrew/lib /usr/local/opt/zmqpp/lib /opt/homebrew/opt/zmqpp/lib )
+find_library( ZMQ_LIB NAMES zmq libzmq
+              PATHS /usr/local/lib /opt/homebrew/lib /usr/local/opt/zeromq/lib /opt/homebrew/opt/zeromq/lib )
+
+# -- X11 GUI tools ------------------------------------------------------------
+#
+find_package(X11)
+if (X11_FOUND)
+  add_executable(seq_progress_gui
+          ${PROJECT_UTILS_DIR}/seq_progress_gui.cpp
+          )
+  target_include_directories(seq_progress_gui PRIVATE
+          ${X11_INCLUDE_DIR}
+          ${PROJECT_BASE_DIR}/common
+          ${PROJECT_UTILS_DIR}
+          )
+  target_link_libraries(seq_progress_gui PRIVATE
+          ${STDCXXFS_LIB}
+          logentry
+          network
+          utilities
+          ${ZMQPP_LIB}
+          ${ZMQ_LIB}
+          ${X11_LIBRARIES}
+          )
+endif()
 

--- a/utils/seq_progress_gui.cpp
+++ b/utils/seq_progress_gui.cpp
@@ -1,0 +1,1247 @@
+// Small X11 sequencer progress popup with ontarget/usercontinue controls.
+// Uses ZMQ telemetry and TCP polling fallback.
+
+#define Time X11Time
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/keysym.h>
+#undef Time
+
+#include <sys/select.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <csignal>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "common.h"
+#include "config.h"
+#include "logentry.h"
+#include "network.h"
+
+namespace {
+
+constexpr int kPhaseCount = 5;
+enum PhaseIndex {
+  PHASE_SLEW = 0,
+  PHASE_SOLVE = 1,
+  PHASE_FINE = 2,
+  PHASE_OFFSET = 3,
+  PHASE_EXPOSE = 4
+};
+
+struct Rect {
+  int x = 0;
+  int y = 0;
+  int w = 0;
+  int h = 0;
+  bool contains(int px, int py) const {
+    return px >= x && px <= (x + w) && py >= y && py <= (y + h);
+  }
+};
+
+struct Options {
+  std::string config_path;
+  std::string host = "127.0.0.1";
+  int nbport = 0;
+  std::string acam_config_path;
+  std::string acam_host;
+  int acam_nbport = 0;
+  std::string pub_endpoint;
+  std::string sub_endpoint;
+  bool pub_endpoint_set = false;
+  bool sub_endpoint_set = false;
+  int poll_ms = 10000;
+};
+
+struct SequenceState {
+  bool phase_complete[kPhaseCount] = {false, false, false, false, false};
+  bool phase_active[kPhaseCount] = {false, false, false, false, false};
+  bool offset_applicable = false;
+  bool waiting_for_user = false;
+  bool waiting_for_tcsop = false;
+  bool ontarget = false;
+  bool guiding_on = false;
+  double exposure_progress = 0.0;
+  double exposure_elapsed = 0.0;
+  double exposure_total = 0.0;
+  int current_phase = -1;
+  bool prev_wait_tcsop = false;
+  bool prev_wait_guide = false;
+  std::string seqstate;
+  std::string waitstate;
+  std::chrono::steady_clock::time_point last_ontarget;
+  int current_obsid = -1;
+  std::string current_target_state;
+  double offset_ra = 0.0;
+  double offset_dec = 0.0;
+  int nexp = 1;
+  int acqmode = 1;
+  int current_frame = 0;
+  int max_frame_seen = 0;
+
+  void reset() {
+    for (int i = 0; i < kPhaseCount; ++i) {
+      phase_complete[i] = false;
+      phase_active[i] = false;
+    }
+    offset_applicable = false;
+    waiting_for_user = false;
+    waiting_for_tcsop = false;
+    ontarget = false;
+    guiding_on = false;
+    exposure_progress = 0.0;
+    exposure_elapsed = 0.0;
+    exposure_total = 0.0;
+    current_phase = -1;
+    prev_wait_tcsop = false;
+    prev_wait_guide = false;
+    seqstate.clear();
+    waitstate.clear();
+    current_obsid = -1;
+    current_target_state.clear();
+    nexp = 1;
+    current_frame = 0;
+    max_frame_seen = 0;
+  }
+
+  void reset_progress_only() {
+    for (int i = 0; i < kPhaseCount; ++i) {
+      phase_complete[i] = false;
+      phase_active[i] = false;
+    }
+    offset_applicable = false;
+    waiting_for_user = false;
+    waiting_for_tcsop = false;
+    ontarget = false;
+    guiding_on = false;
+    exposure_progress = 0.0;
+    exposure_elapsed = 0.0;
+    exposure_total = 0.0;
+    current_phase = -1;
+    prev_wait_tcsop = false;
+    prev_wait_guide = false;
+  }
+};
+
+static bool starts_with_local(const std::string &s, const std::string &prefix) {
+  return s.rfind(prefix, 0) == 0;
+}
+
+static std::string trim_copy(std::string s) {
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+  s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
+  return s;
+}
+
+static std::vector<std::string> split_ws(const std::string &s) {
+  std::istringstream iss(s);
+  std::vector<std::string> out;
+  std::string tok;
+  while (iss >> tok) out.push_back(tok);
+  return out;
+}
+
+static bool has_token(const std::vector<std::string> &tokens, const std::string &needle) {
+  return std::find(tokens.begin(), tokens.end(), needle) != tokens.end();
+}
+
+static std::string to_upper_copy(std::string s);
+
+static std::string strip_token_edges(std::string s) {
+  while (!s.empty() && !std::isalnum(static_cast<unsigned char>(s.front()))) s.erase(s.begin());
+  while (!s.empty() && !std::isalnum(static_cast<unsigned char>(s.back()))) s.pop_back();
+  return s;
+}
+
+static std::vector<std::string> split_state_tokens(const std::string &s) {
+  std::vector<std::string> out;
+  auto tokens = split_ws(to_upper_copy(s));
+  out.reserve(tokens.size());
+  for (auto &tok : tokens) {
+    std::string cleaned = strip_token_edges(tok);
+    if (!cleaned.empty()) out.push_back(cleaned);
+  }
+  return out;
+}
+
+static Options parse_args(int argc, char **argv) {
+  Options opt;
+  if (const char *env_host = std::getenv("NGPS_HOST"); env_host && *env_host) {
+    opt.host = env_host;
+  }
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--config" && i + 1 < argc) {
+      opt.config_path = argv[++i];
+    } else if (arg == "--host" && i + 1 < argc) {
+      opt.host = argv[++i];
+    } else if (arg == "--nbport" && i + 1 < argc) {
+      opt.nbport = std::stoi(argv[++i]);
+    } else if (arg == "--acam-config" && i + 1 < argc) {
+      opt.acam_config_path = argv[++i];
+    } else if (arg == "--acam-host" && i + 1 < argc) {
+      opt.acam_host = argv[++i];
+    } else if (arg == "--acam-nbport" && i + 1 < argc) {
+      opt.acam_nbport = std::stoi(argv[++i]);
+    } else if (arg == "--pub-endpoint" && i + 1 < argc) {
+      opt.pub_endpoint = argv[++i];
+      opt.pub_endpoint_set = true;
+    } else if (arg == "--sub-endpoint" && i + 1 < argc) {
+      opt.sub_endpoint = argv[++i];
+      opt.sub_endpoint_set = true;
+    } else if (arg == "--poll-ms" && i + 1 < argc) {
+      opt.poll_ms = std::stoi(argv[++i]);
+    } else if (arg == "--help" || arg == "-h") {
+      std::cout << "Usage: seq_progress_gui [--config <path>] [--host <ip>] [--nbport <port>]\n"
+                   "                        [--acam-config <path>] [--acam-host <ip>] [--acam-nbport <port>]\n"
+                   "                        [--pub-endpoint <zmq>] [--sub-endpoint <zmq>] [--poll-ms <ms>]\n";
+      std::exit(0);
+    }
+  }
+  return opt;
+}
+
+static void load_config(const std::string &path, Options &opt) {
+  if (path.empty()) return;
+  Config cfg(path);
+  if (cfg.read_config(cfg) != 0) return;
+  for (int i = 0; i < cfg.n_entries; ++i) {
+    if (cfg.param[i] == "NBPORT" && opt.nbport <= 0) {
+      opt.nbport = std::stoi(cfg.arg[i]);
+    } else if (cfg.param[i] == "PUB_ENDPOINT" && !opt.pub_endpoint_set) {
+      opt.pub_endpoint = cfg.arg[i];
+    } else if (cfg.param[i] == "SUB_ENDPOINT" && !opt.sub_endpoint_set) {
+      opt.sub_endpoint = cfg.arg[i];
+    }
+  }
+}
+
+static std::string default_config_path() {
+  const char *root = std::getenv("NGPS_ROOT");
+  if (root && *root) {
+    return std::string(root) + "/Config/sequencerd.cfg";
+  }
+  return "Config/sequencerd.cfg";
+}
+
+static std::string default_acam_config_path() {
+  const char *root = std::getenv("NGPS_ROOT");
+  if (root && *root) {
+    return std::string(root) + "/Config/acamd.cfg";
+  }
+  return "Config/acamd.cfg";
+}
+
+static void load_acam_config(const std::string &path, Options &opt) {
+  if (path.empty()) return;
+  Config cfg(path);
+  if (cfg.read_config(cfg) != 0) return;
+  for (int i = 0; i < cfg.n_entries; ++i) {
+    if (cfg.param[i] == "NBPORT" && opt.acam_nbport <= 0) {
+      opt.acam_nbport = std::stoi(cfg.arg[i]);
+    } else if (cfg.param[i] == "HOST" && opt.acam_host.empty()) {
+      opt.acam_host = cfg.arg[i];
+    }
+  }
+}
+
+static std::string to_lower_copy(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+  return s;
+}
+
+static std::string to_upper_copy(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::toupper(c); });
+  return s;
+}
+
+}  // namespace
+
+class SeqProgressGui {
+ public:
+  SeqProgressGui(const Options &opt)
+      : options_(opt),
+        cmd_iface_("sequencer", options_.host, static_cast<uint16_t>(options_.nbport)),
+        acam_iface_("acam", options_.acam_host, static_cast<uint16_t>(options_.acam_nbport)) {}
+
+  bool init() {
+    display_ = XOpenDisplay(nullptr);
+    if (!display_) {
+      std::cerr << "ERROR opening X display\n";
+      return false;
+    }
+
+    int screen = DefaultScreen(display_);
+    unsigned long black = BlackPixel(display_, screen);
+    unsigned long white = WhitePixel(display_, screen);
+
+    window_ = XCreateSimpleWindow(display_, DefaultRootWindow(display_), 100, 100, kWinW, kWinH, 1, black, white);
+    XStoreName(display_, window_, "NGPS Observation Sequence");
+    XSelectInput(display_, window_, ExposureMask | ButtonPressMask | KeyPressMask | StructureNotifyMask);
+
+    wm_delete_window_ = XInternAtom(display_, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(display_, window_, &wm_delete_window_, 1);
+
+    XMapWindow(display_, window_);
+    gc_ = XCreateGC(display_, window_, 0, nullptr);
+
+    load_colors();
+    load_font();
+    compute_layout();
+
+    init_zmq();
+
+    if (options_.nbport > 0) {
+      if (cmd_iface_.open() == 0) {
+        cmd_iface_.send_command("state");
+        cmd_iface_.send_command("wstate");
+      }
+    }
+    if (options_.acam_nbport > 0) {
+      acam_iface_.open();
+    }
+
+    return true;
+  }
+
+  void run() {
+    const int xfd = ConnectionNumber(display_);
+    bool running = true;
+    bool need_redraw = true;
+    auto last_blink = std::chrono::steady_clock::now();
+    bool blink_on = false;
+
+    while (running) {
+      fd_set fds;
+      FD_ZERO(&fds);
+      FD_SET(xfd, &fds);
+      int maxfd = xfd;
+
+      struct timeval tv;
+      tv.tv_sec = 0;
+      tv.tv_usec = 200000;  // 200ms
+
+      int ret = select(maxfd + 1, &fds, nullptr, nullptr, &tv);
+      if (ret > 0) {
+        if (FD_ISSET(xfd, &fds)) {
+          while (XPending(display_)) {
+            XEvent ev;
+            XNextEvent(display_, &ev);
+            if (ev.type == Expose) {
+              need_redraw = true;
+            } else if (ev.type == ButtonPress) {
+              handle_click(ev.xbutton.x, ev.xbutton.y);
+              need_redraw = true;
+            } else if (ev.type == KeyPress) {
+              KeySym ks = XLookupKeysym(&ev.xkey, 0);
+              if (ks == XK_Escape) {
+                running = false;
+              }
+            } else if (ev.type == ClientMessage) {
+              if (static_cast<Atom>(ev.xclient.data.l[0]) == wm_delete_window_) {
+                running = false;
+              }
+            }
+          }
+        }
+      }
+
+      auto now = std::chrono::steady_clock::now();
+      if (process_zmq()) {
+        need_redraw = true;
+      }
+      if (maybe_poll(now)) {
+        need_redraw = true;
+      }
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_blink).count() > 600) {
+        blink_on = !blink_on;
+        last_blink = now;
+        need_redraw = true;
+      }
+
+      blink_on_ = blink_on;
+      if (need_redraw) {
+        draw();
+        need_redraw = false;
+      }
+    }
+  }
+
+ private:
+  const int kWinW = 900;
+  const int kWinH = 220;
+
+  Options options_;
+  Network::Interface cmd_iface_;
+  Network::Interface acam_iface_;
+  zmqpp::context zmq_context_;
+  std::unique_ptr<Common::PubSub> zmq_sub_;
+  std::unique_ptr<Common::PubSub> zmq_pub_;
+  SequenceState state_;
+  std::chrono::steady_clock::time_point last_zmq_seqstate_;
+  std::chrono::steady_clock::time_point last_zmq_waitstate_;
+  std::chrono::steady_clock::time_point last_zmq_any_;
+  std::chrono::steady_clock::time_point last_snapshot_request_;
+  std::chrono::steady_clock::time_point last_acam_poll_;
+  std::chrono::steady_clock::time_point last_seq_poll_;
+  std::chrono::steady_clock::time_point last_seqstate_update_;
+  std::chrono::steady_clock::time_point last_waitstate_update_;
+
+  Display *display_ = nullptr;
+  Window window_ = 0;
+  GC gc_ = 0;
+  Atom wm_delete_window_{};
+  bool blink_on_ = false;
+
+  Rect bar_;
+  Rect segments_[kPhaseCount];
+  Rect ontarget_btn_;
+  Rect continue_btn_;
+  Rect guiding_box_;
+  Rect seqstatus_box_;
+
+  unsigned long color_bg_ = 0;
+  unsigned long color_text_ = 0;
+  unsigned long color_complete_ = 0;
+  unsigned long color_active_ = 0;
+  unsigned long color_pending_ = 0;
+  unsigned long color_disabled_ = 0;
+  unsigned long color_button_ = 0;
+  unsigned long color_button_disabled_ = 0;
+  unsigned long color_button_text_ = 0;
+  unsigned long color_wait_ = 0;
+
+  XFontStruct *font_ = nullptr;
+
+  void init_zmq() {
+    if (!options_.sub_endpoint.empty()) {
+      try {
+        zmq_sub_ = std::make_unique<Common::PubSub>(zmq_context_, Common::PubSub::Mode::SUB);
+        zmq_sub_->connect(options_.sub_endpoint);
+        zmq_sub_->subscribe("seq_seqstate");
+        zmq_sub_->subscribe("seq_waitstate");
+        zmq_sub_->subscribe("seq_threadstate");
+        zmq_sub_->subscribe("seq_daemonstate");
+        zmq_sub_->subscribe("seq_progress");
+        zmq_sub_->subscribe("acamd");
+      } catch (const std::exception &e) {
+        std::cerr << "ERROR initializing ZMQ subscriber: " << e.what() << "\n";
+      }
+    }
+
+    if (!options_.pub_endpoint.empty()) {
+      try {
+        zmq_pub_ = std::make_unique<Common::PubSub>(zmq_context_, Common::PubSub::Mode::PUB);
+        zmq_pub_->connect_to_broker(options_.pub_endpoint, "seq_progress_gui");
+      } catch (const std::exception &e) {
+        std::cerr << "ERROR initializing ZMQ publisher: " << e.what() << "\n";
+      }
+    }
+
+    request_snapshot();
+  }
+
+  void load_colors() {
+    int screen = DefaultScreen(display_);
+    Colormap cmap = DefaultColormap(display_, screen);
+    color_bg_ = alloc_color(cmap, "#e6e6e6");
+    color_text_ = alloc_color(cmap, "#111111");
+    color_complete_ = alloc_color(cmap, "#2e7d32");
+    color_active_ = alloc_color(cmap, "#f9a825");
+    color_pending_ = alloc_color(cmap, "#b0b0b0");
+    color_disabled_ = alloc_color(cmap, "#808080");
+    color_button_ = alloc_color(cmap, "#1565c0");
+    color_button_disabled_ = alloc_color(cmap, "#9e9e9e");
+    color_button_text_ = alloc_color(cmap, "#ffffff");
+    color_wait_ = alloc_color(cmap, "#c62828");
+  }
+
+  unsigned long alloc_color(Colormap cmap, const char *hex) {
+    XColor color;
+    XParseColor(display_, cmap, hex, &color);
+    XAllocColor(display_, cmap, &color);
+    return color.pixel;
+  }
+
+  void load_font() {
+    font_ = XLoadQueryFont(display_, "9x15bold");
+    if (!font_) {
+      font_ = XLoadQueryFont(display_, "fixed");
+    }
+    if (font_) {
+      XSetFont(display_, gc_, font_->fid);
+    }
+  }
+
+  void compute_layout() {
+    const int margin = 16;
+    bar_.x = margin;
+    bar_.y = 48;
+    bar_.w = kWinW - 2 * margin;
+    bar_.h = 26;
+
+    int seg_w = bar_.w / kPhaseCount;
+    for (int i = 0; i < kPhaseCount; ++i) {
+      segments_[i] = {bar_.x + i * seg_w, bar_.y, seg_w, bar_.h};
+    }
+    segments_[kPhaseCount - 1].w = bar_.w - (seg_w * (kPhaseCount - 1));
+
+    ontarget_btn_ = {margin, 150, 160, 34};
+    continue_btn_ = {margin + 180, 150, 160, 34};
+    guiding_box_ = {margin + 520, 150, 160, 34};
+    seqstatus_box_ = {guiding_box_.x + guiding_box_.w + 12, 150, 180, 34};
+  }
+
+  void draw() {
+    XSetForeground(display_, gc_, color_bg_);
+    XFillRectangle(display_, window_, gc_, 0, 0, kWinW, kWinH);
+
+    draw_title();
+    draw_acqmode_indicator();
+    draw_bar();
+    draw_labels();
+    draw_user_instruction();
+    draw_buttons();
+    draw_ontarget_indicator();
+    draw_offset_values();
+    draw_guiding_indicator();
+    draw_seqstatus_indicator();
+
+    XFlush(display_);
+  }
+
+  void draw_title() {
+    XSetForeground(display_, gc_, color_text_);
+    const char *title = "Observation Sequence Progress";
+    XDrawString(display_, window_, gc_, 16, 24, title, std::strlen(title));
+  }
+
+  void draw_acqmode_indicator() {
+    const char *label;
+    switch (state_.acqmode) {
+      case 2:  label = "ACQMODE: 2 SEMI-AUTO"; break;
+      case 3:  label = "ACQMODE: 3 AUTO";      break;
+      default: label = "ACQMODE: 1 MANUAL";    break;
+    }
+    int len = std::strlen(label);
+    int text_width = XTextWidth(XQueryFont(display_, XGContextFromGC(gc_)), label, len);
+    XSetForeground(display_, gc_, color_text_);
+    XDrawString(display_, window_, gc_, kWinW - text_width - 16, 24, label, len);
+  }
+
+  void draw_bar() {
+    for (int i = 0; i < kPhaseCount; ++i) {
+      unsigned long fill = color_pending_;
+      if (i == PHASE_OFFSET && !state_.offset_applicable) {
+        fill = color_disabled_;
+      } else if (state_.phase_complete[i]) {
+        fill = color_complete_;
+      } else if (state_.phase_active[i]) {
+        fill = color_active_;
+      }
+
+      XSetForeground(display_, gc_, fill);
+      XFillRectangle(display_, window_, gc_, segments_[i].x, segments_[i].y, segments_[i].w, segments_[i].h);
+
+      if (i == PHASE_EXPOSE && state_.phase_active[i] && state_.exposure_progress > 0.0) {
+        int prog_w = static_cast<int>(segments_[i].w * std::min(1.0, state_.exposure_progress));
+        XSetForeground(display_, gc_, color_complete_);
+        XFillRectangle(display_, window_, gc_, segments_[i].x, segments_[i].y, prog_w, segments_[i].h);
+      }
+
+      XSetForeground(display_, gc_, color_text_);
+      XDrawRectangle(display_, window_, gc_, segments_[i].x, segments_[i].y, segments_[i].w, segments_[i].h);
+    }
+  }
+
+  void draw_labels() {
+    XSetForeground(display_, gc_, color_text_);
+    const char *labels[kPhaseCount] = {"SLEW", "ASTROM SOLVE", "FINE TUNE", "OFFSET", "EXPOSURE"};
+    int label_y = bar_.y + bar_.h + 16;
+    for (int i = 0; i < kPhaseCount; ++i) {
+      int tx = segments_[i].x + 6;
+      // Add info to EXPOSURE label when active
+      if (i == PHASE_EXPOSE && state_.phase_active[PHASE_EXPOSE]) {
+        char exp_label[64];
+        int percent = static_cast<int>(state_.exposure_progress * 100.0);
+        if (state_.nexp > 1) {
+          snprintf(exp_label, sizeof(exp_label), "EXPOSURE %d/%d %d%%",
+                   state_.current_frame, state_.nexp, percent);
+        } else {
+          snprintf(exp_label, sizeof(exp_label), "EXPOSURE %d%%", percent);
+        }
+        static int debug_counter = 0;
+        if (++debug_counter % 10 == 0) {  // Print every 10th frame to avoid spam
+          std::cerr << "DEBUG drawing label: " << exp_label
+                    << " (exposure_progress=" << state_.exposure_progress << ")\n";
+        }
+        XDrawString(display_, window_, gc_, tx, label_y, exp_label, std::strlen(exp_label));
+      } else {
+        XDrawString(display_, window_, gc_, tx, label_y, labels[i], std::strlen(labels[i]));
+      }
+    }
+  }
+
+  void draw_status() {
+    std::string status = "IDLE";
+    if (state_.waiting_for_tcsop) {
+      status = "WAITING FOR TCS OPERATOR (ONTARGET)";
+    } else if (state_.waiting_for_user) {
+      status = "WAITING FOR USER ACTION";
+    } else if (state_.phase_active[PHASE_SLEW]) {
+      status = "SLEWING";
+    } else if (state_.phase_active[PHASE_SOLVE]) {
+      status = "ASTROM SOLVE";
+    } else if (state_.phase_active[PHASE_FINE]) {
+      status = "FINE TUNE";
+    } else if (state_.phase_active[PHASE_OFFSET]) {
+      status = "APPLYING OFFSET";
+    } else if (state_.phase_active[PHASE_EXPOSE]) {
+      std::ostringstream oss;
+      // Show frame count if NEXP > 1
+      if (state_.nexp > 1) {
+        oss << "EXPOSURE " << state_.current_frame << " / " << state_.nexp;
+        if (state_.exposure_total > 0.0) {
+          oss.setf(std::ios::fixed);
+          oss.precision(1);
+          oss << " (" << state_.exposure_elapsed << " / " << state_.exposure_total << " s)";
+        }
+      } else {
+        oss << "EXPOSURE";
+        if (state_.exposure_total > 0.0) {
+          oss.setf(std::ios::fixed);
+          oss.precision(1);
+          oss << " " << state_.exposure_elapsed << " / " << state_.exposure_total << " s";
+        }
+        if (state_.exposure_progress > 0.0) {
+          oss << " " << static_cast<int>(state_.exposure_progress * 100.0) << "%";
+        }
+      }
+      status = oss.str();
+    }
+
+    unsigned long color = (state_.waiting_for_tcsop || state_.waiting_for_user) && blink_on_ ? color_wait_ : color_text_;
+    XSetForeground(display_, gc_, color);
+    XDrawString(display_, window_, gc_, 16, 116, status.c_str(), static_cast<int>(status.size()));
+  }
+
+  void draw_button(const Rect &r, const char *label, bool enabled) {
+    unsigned long fill = enabled ? color_button_ : color_button_disabled_;
+    XSetForeground(display_, gc_, fill);
+    XFillRectangle(display_, window_, gc_, r.x, r.y, r.w, r.h);
+    XSetForeground(display_, gc_, color_text_);
+    XDrawRectangle(display_, window_, gc_, r.x, r.y, r.w, r.h);
+    XSetForeground(display_, gc_, color_button_text_);
+    int tx = r.x + 10;
+    int ty = r.y + 22;
+    XDrawString(display_, window_, gc_, tx, ty, label, std::strlen(label));
+  }
+
+  enum class UserGateIntent {
+    CONTINUE,
+    ACQUIRE,
+    EXPOSE,
+    OFFSET_EXPOSE
+  };
+
+  bool has_pending_target_offset() const {
+    return state_.offset_applicable ||
+           std::fabs(state_.offset_ra) > 1.0e-6 ||
+           std::fabs(state_.offset_dec) > 1.0e-6;
+  }
+
+  bool is_pre_acquire_gate() const {
+    if (!state_.waiting_for_user) return false;
+    if (state_.acqmode != 2) return false;
+    return !state_.phase_active[PHASE_SOLVE] &&
+           !state_.phase_complete[PHASE_SOLVE] &&
+           !state_.phase_active[PHASE_FINE] &&
+           !state_.phase_complete[PHASE_FINE] &&
+           !state_.phase_active[PHASE_OFFSET] &&
+           !state_.phase_complete[PHASE_OFFSET] &&
+           !state_.phase_active[PHASE_EXPOSE] &&
+           state_.current_frame == 0 &&
+           !state_.guiding_on;
+  }
+
+  UserGateIntent infer_user_gate_intent() const {
+    if (!state_.waiting_for_user) return UserGateIntent::CONTINUE;
+    if (is_pre_acquire_gate()) return UserGateIntent::ACQUIRE;
+    if (has_pending_target_offset()) return UserGateIntent::OFFSET_EXPOSE;
+    if (state_.acqmode == 2 || state_.acqmode == 3) return UserGateIntent::EXPOSE;
+    return UserGateIntent::CONTINUE;
+  }
+
+  const char *continue_label() const {
+    switch (infer_user_gate_intent()) {
+      case UserGateIntent::ACQUIRE:      return "ACQUIRE";
+      case UserGateIntent::EXPOSE:       return "EXPOSE";
+      case UserGateIntent::OFFSET_EXPOSE:return "OFFSET & EXPOSE";
+      default:                           return "CONTINUE";
+    }
+  }
+
+  void draw_user_instruction() {
+    if (!state_.waiting_for_user) return;
+    if (!blink_on_) return;  // blink the instruction for visibility
+
+    char instruction[256];
+    switch (infer_user_gate_intent()) {
+      case UserGateIntent::ACQUIRE:
+        snprintf(instruction, sizeof(instruction),
+                 ">>> Click ACQUIRE to start acquisition <<<");
+        break;
+      case UserGateIntent::OFFSET_EXPOSE:
+        snprintf(instruction, sizeof(instruction),
+                 ">>> Click OFFSET & EXPOSE to apply offset (RA=%.2f\" DEC=%.2f\") then expose <<<",
+                 state_.offset_ra, state_.offset_dec);
+        break;
+      case UserGateIntent::EXPOSE:
+        snprintf(instruction, sizeof(instruction),
+                 ">>> Click EXPOSE to begin exposure <<<");
+        break;
+      default:
+        snprintf(instruction, sizeof(instruction),
+                 ">>> Click CONTINUE <<<");
+        break;
+    }
+
+    XSetForeground(display_, gc_, color_wait_);  // red bold
+    XDrawString(display_, window_, gc_, 16, 118, instruction, std::strlen(instruction));
+  }
+
+  void draw_buttons() {
+    draw_button(ontarget_btn_, "ONTARGET", state_.waiting_for_tcsop);
+    draw_button(continue_btn_, continue_label(), state_.waiting_for_user);
+  }
+
+  void draw_ontarget_indicator() {
+    const char *label = state_.ontarget ? "ONTARGET: YES" : "ONTARGET: NO";
+    unsigned long color = state_.ontarget ? color_complete_ : color_pending_;
+    XSetForeground(display_, gc_, color);
+    XFillArc(display_, window_, gc_, 370, 150, 18, 18, 0, 360 * 64);
+    XSetForeground(display_, gc_, color_text_);
+    XDrawString(display_, window_, gc_, 394, 164, label, std::strlen(label));
+  }
+
+  void draw_offset_values() {
+    // Display offset values above the guiding indicator box
+    char label[64];
+    snprintf(label, sizeof(label), "Offset: RA=%.2f\" DEC=%.2f\"",
+             state_.offset_ra, state_.offset_dec);
+    XSetForeground(display_, gc_, color_text_);
+    XDrawString(display_, window_, gc_, guiding_box_.x, guiding_box_.y - 8, label, std::strlen(label));
+  }
+
+  void draw_guiding_indicator() {
+    const char *label = state_.guiding_on ? "GUIDING ON" : "GUIDING OFF";
+    unsigned long fill = state_.guiding_on ? color_complete_ : color_wait_;
+    XSetForeground(display_, gc_, fill);
+    XFillRectangle(display_, window_, gc_, guiding_box_.x, guiding_box_.y, guiding_box_.w, guiding_box_.h);
+    XSetForeground(display_, gc_, color_text_);
+    XDrawRectangle(display_, window_, gc_, guiding_box_.x, guiding_box_.y, guiding_box_.w, guiding_box_.h);
+    XSetForeground(display_, gc_, color_button_text_);
+    int tx = guiding_box_.x + 10;
+    int ty = guiding_box_.y + 22;
+    XDrawString(display_, window_, gc_, tx, ty, label, std::strlen(label));
+  }
+
+  void draw_seqstatus_indicator() {
+    std::string label;
+    unsigned long fill = color_pending_;
+    auto seq_tokens = split_state_tokens(state_.seqstate);
+    const bool has_ready = has_token(seq_tokens, "READY");
+    const bool has_notready = has_token(seq_tokens, "NOTREADY") || (has_token(seq_tokens, "NOT") && has_ready);
+    const bool has_running = has_token(seq_tokens, "RUNNING");
+    const bool has_paused = has_token(seq_tokens, "PAUSED");
+    const bool has_starting = has_token(seq_tokens, "STARTING");
+    const bool has_stopping = has_token(seq_tokens, "STOPPING");
+    const bool have_zmq = (zmq_sub_ != nullptr);
+    const int stale_ms = have_zmq ? 5000 : (options_.poll_ms > 0 ? options_.poll_ms * 2 : 5000);
+    const bool seq_stale = is_stale(last_seqstate_update_, stale_ms);
+    const bool wait_stale = is_stale(last_waitstate_update_, stale_ms);
+
+    if (seq_stale && wait_stale) {
+      label = "STALE";
+      fill = color_disabled_;
+    } else if (state_.waiting_for_tcsop) {
+      label = "WAITING: TCSOP";
+      fill = color_wait_;
+    } else if (state_.waiting_for_user) {
+      label = "WAITING: USER";
+      fill = color_wait_;
+    } else if (!state_.waitstate.empty()) {
+      label = "WAITING";
+      fill = color_wait_;
+    } else if (has_stopping) {
+      label = "STOPPING";
+      fill = color_active_;
+    } else if (has_starting) {
+      label = "STARTING";
+      fill = color_active_;
+    } else if (has_paused) {
+      label = "PAUSED";
+      fill = color_wait_;
+    } else if (has_running) {
+      label = "RUNNING";
+      fill = color_active_;
+    } else if (has_notready) {
+      label = "NOTREADY";
+      fill = color_disabled_;
+    } else if (has_ready) {
+      label = "READY";
+      fill = color_complete_;
+    } else {
+      label = "UNKNOWN";
+      fill = color_pending_;
+    }
+
+    std::string text = "SEQ " + label;
+    XSetForeground(display_, gc_, fill);
+    XFillRectangle(display_, window_, gc_, seqstatus_box_.x, seqstatus_box_.y, seqstatus_box_.w, seqstatus_box_.h);
+    XSetForeground(display_, gc_, color_text_);
+    XDrawRectangle(display_, window_, gc_, seqstatus_box_.x, seqstatus_box_.y, seqstatus_box_.w, seqstatus_box_.h);
+    XSetForeground(display_, gc_, color_button_text_);
+    int tx = seqstatus_box_.x + 10;
+    int ty = seqstatus_box_.y + 22;
+    XDrawString(display_, window_, gc_, tx, ty, text.c_str(), static_cast<int>(text.size()));
+  }
+
+  void handle_click(int x, int y) {
+    if (ontarget_btn_.contains(x, y) && state_.waiting_for_tcsop) {
+      send_command("ontarget");
+    }
+    if (continue_btn_.contains(x, y) && state_.waiting_for_user) {
+      send_command("usercontinue");
+    }
+  }
+
+  void send_command(const std::string &cmd) {
+    if (!cmd_iface_.isopen()) {
+      cmd_iface_.open();
+    }
+    if (cmd_iface_.send_command(cmd) != 0) {
+      cmd_iface_.reconnect();
+      cmd_iface_.send_command(cmd);
+    }
+  }
+
+  bool process_zmq() {
+    if (!zmq_sub_) return false;
+    if (!zmq_sub_->has_message()) return false;
+    auto [topic, payload] = zmq_sub_->receive();
+    handle_zmq_message(topic, payload);
+    return true;
+  }
+
+  void handle_zmq_message(const std::string &topic, const std::string &payload) {
+    try {
+      nlohmann::json jmessage = nlohmann::json::parse(payload);
+      auto now = std::chrono::steady_clock::now();
+      last_zmq_any_ = now;
+      if (topic == "seq_seqstate" && jmessage.contains("seqstate")) {
+        handle_message("SEQSTATE: " + jmessage["seqstate"].get<std::string>());
+        last_zmq_seqstate_ = now;
+      } else if (topic == "seq_waitstate") {
+        static const char *kWaitTokens[] = {"ACAM",    "CALIB",  "CAMERA", "FLEXURE", "FOCUS",
+                                            "POWER",   "SLICECAM", "SLIT",   "TCS",     "ACQUIRE",
+                                            "GUIDE",   "EXPOSE", "READOUT", "TCSOP",  "USER"};
+        std::string waitstate;
+        for (const char *token : kWaitTokens) {
+          if (jmessage.contains(token) && jmessage[token].is_boolean() && jmessage[token].get<bool>()) {
+            if (!waitstate.empty()) waitstate += " ";
+            waitstate += token;
+          }
+        }
+        handle_waitstate(waitstate);
+        last_zmq_waitstate_ = now;
+      } else if (topic == "seq_progress") {
+        if (jmessage.contains("obsid") && jmessage["obsid"].is_number_integer()) {
+          int obsid = jmessage["obsid"].get<int>();
+          if (obsid > 0 && state_.current_obsid != obsid) {
+            state_.reset_progress_only();
+          }
+          state_.current_obsid = obsid;
+        }
+        if (jmessage.contains("target_state") && jmessage["target_state"].is_string()) {
+          std::string tstate = to_upper_copy(jmessage["target_state"].get<std::string>());
+          if (!tstate.empty() && tstate != state_.current_target_state) {
+            if (tstate == "ACTIVE" || tstate == "COMPLETE" || tstate == "PENDING") {
+              state_.reset_progress_only();
+            }
+          }
+          state_.current_target_state = tstate;
+        }
+        if (jmessage.contains("event") && jmessage["event"].is_string()) {
+          std::string event = to_lower_copy(jmessage["event"].get<std::string>());
+          if (event == "target_start" || event == "target_complete" || event == "wait_tcsop") {
+            state_.reset_progress_only();
+          }
+        }
+        if (jmessage.contains("ontarget") && jmessage["ontarget"].is_boolean()) {
+          state_.ontarget = jmessage["ontarget"].get<bool>();
+        }
+        if (jmessage.contains("fine_tune_active") && jmessage["fine_tune_active"].is_boolean()) {
+          bool active = jmessage["fine_tune_active"].get<bool>();
+          if (active) {
+            set_phase(PHASE_FINE);
+          } else if (state_.phase_active[PHASE_FINE]) {
+            state_.phase_complete[PHASE_FINE] = true;
+            clear_phase_active(PHASE_FINE);
+          }
+        }
+        bool offset_active = false;
+        if (jmessage.contains("offset_active") && jmessage["offset_active"].is_boolean()) {
+          offset_active = jmessage["offset_active"].get<bool>();
+        }
+        if (jmessage.contains("offset_settle") && jmessage["offset_settle"].is_boolean()) {
+          offset_active = offset_active || jmessage["offset_settle"].get<bool>();
+        }
+        if (offset_active) {
+          state_.offset_applicable = true;
+          set_phase(PHASE_OFFSET);
+        } else if (state_.phase_active[PHASE_OFFSET]) {
+          state_.phase_complete[PHASE_OFFSET] = true;
+          clear_phase_active(PHASE_OFFSET);
+        }
+        if (jmessage.contains("offset_ra") && jmessage["offset_ra"].is_number()) {
+          state_.offset_ra = jmessage["offset_ra"].get<double>();
+        }
+        if (jmessage.contains("offset_dec") && jmessage["offset_dec"].is_number()) {
+          state_.offset_dec = jmessage["offset_dec"].get<double>();
+        }
+        if (jmessage.contains("acqmode") && jmessage["acqmode"].is_number()) {
+          state_.acqmode = jmessage["acqmode"].get<int>();
+        }
+        if (jmessage.contains("nexp") && jmessage["nexp"].is_number()) {
+          int new_nexp = jmessage["nexp"].get<int>();
+          if (new_nexp != state_.nexp) {
+            state_.nexp = new_nexp;
+            // Reset frame tracking when nexp changes
+            state_.current_frame = 0;
+            state_.max_frame_seen = 0;
+          }
+        }
+        if (jmessage.contains("current_frame") && jmessage["current_frame"].is_number()) {
+          int frame = jmessage["current_frame"].get<int>();
+          if (frame > state_.max_frame_seen) {
+            state_.max_frame_seen = frame;
+            state_.current_frame = frame;
+            // Keep EXPOSE phase active if more frames expected
+            if (state_.current_frame < state_.nexp) {
+              set_phase(PHASE_EXPOSE);
+            } else if (state_.current_frame >= state_.nexp) {
+              // All frames complete
+              state_.phase_complete[PHASE_EXPOSE] = true;
+              clear_phase_active(PHASE_EXPOSE);
+            }
+          }
+        }
+        if (jmessage.contains("exptime_percent") && jmessage["exptime_percent"].is_number()) {
+          int percent = jmessage["exptime_percent"].get<int>();
+          percent = std::max(0, std::min(100, percent));
+          state_.exposure_progress = percent / 100.0;
+          set_phase(PHASE_EXPOSE);
+        }
+      } else if (topic == "acamd") {
+        if (jmessage.contains("ACAM_GUIDING") && jmessage["ACAM_GUIDING"].is_boolean()) {
+          state_.guiding_on = jmessage["ACAM_GUIDING"].get<bool>();
+        } else if (jmessage.contains("ACAM_ACQUIRE_MODE") && jmessage["ACAM_ACQUIRE_MODE"].is_string()) {
+          std::string mode = to_lower_copy(jmessage["ACAM_ACQUIRE_MODE"].get<std::string>());
+          state_.guiding_on = (mode.find("guiding") != std::string::npos);
+        }
+      }
+    } catch (const std::exception &) {
+      // ignore malformed telemetry
+    }
+  }
+
+  void request_snapshot() {
+    if (!zmq_pub_) return;
+    nlohmann::json jmessage;
+    jmessage["sequencerd"] = true;
+    jmessage["acamd"] = true;
+    zmq_pub_->publish(jmessage, "_snapshot");
+    last_snapshot_request_ = std::chrono::steady_clock::now();
+  }
+
+  bool is_stale(const std::chrono::steady_clock::time_point &tp, int stale_ms) const {
+    if (tp.time_since_epoch().count() == 0) return true;
+    auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(now - tp).count() > stale_ms;
+  }
+
+  bool should_poll_acam() const {
+    if (state_.seqstate.find("RUNNING") != std::string::npos) return true;
+    if (state_.waitstate.find("ACQUIRE") != std::string::npos) return true;
+    if (state_.waitstate.find("GUIDE") != std::string::npos) return true;
+    if (state_.waitstate.find("EXPOSE") != std::string::npos) return true;
+    if (state_.waitstate.find("READOUT") != std::string::npos) return true;
+    return false;
+  }
+
+  bool maybe_poll(const std::chrono::steady_clock::time_point &now) {
+    bool updated = false;
+    const int stale_ms = 5000;
+    const bool have_zmq = (zmq_sub_ != nullptr);
+    const bool stale_seq = have_zmq &&
+                           (is_stale(last_zmq_seqstate_, stale_ms) ||
+                            is_stale(last_zmq_waitstate_, stale_ms));
+    const bool zmq_quiet = have_zmq && is_stale(last_zmq_any_, options_.poll_ms > 0 ? options_.poll_ms * 3 : stale_ms * 3);
+    const bool allow_tcp_poll = !have_zmq || (zmq_quiet && stale_seq);
+
+    if (options_.poll_ms > 0) {
+      if (have_zmq && zmq_pub_ && state_.waiting_for_user &&
+          std::chrono::duration_cast<std::chrono::milliseconds>(now - last_snapshot_request_).count() >= 1000) {
+        request_snapshot();
+        updated = true;
+      }
+      if (have_zmq && zmq_pub_) {
+        if (stale_seq &&
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - last_snapshot_request_).count() >= stale_ms) {
+          request_snapshot();
+          updated = true;
+        }
+      }
+      if (allow_tcp_poll) {
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_seq_poll_).count() >= options_.poll_ms) {
+          poll_sequencer();
+          last_seq_poll_ = now;
+          updated = true;
+        }
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_acam_poll_).count() >= options_.poll_ms) {
+          if (should_poll_acam()) {
+            poll_acam();
+            updated = true;
+          }
+          last_acam_poll_ = now;
+        }
+      }
+    } else if (have_zmq && zmq_pub_) {
+      if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_snapshot_request_).count() >= stale_ms) {
+        request_snapshot();
+        updated = true;
+      }
+    }
+
+    return updated;
+  }
+
+  void poll_status() {
+    poll_sequencer();
+    poll_acam();
+  }
+
+  void poll_sequencer() {
+    if (options_.nbport <= 0) return;
+    if (!cmd_iface_.isopen()) {
+      if (cmd_iface_.open() != 0) return;
+    }
+
+    std::string reply;
+    if (cmd_iface_.send_command("state", reply, 200) == 0 && !reply.empty()) {
+      handle_message("SEQSTATE: " + reply);
+    } else if (!cmd_iface_.isopen()) {
+      cmd_iface_.reconnect();
+      return;
+    }
+
+    reply.clear();
+    if (cmd_iface_.send_command("wstate", reply, 200) == 0 && !reply.empty()) {
+      handle_waitstate(reply);
+    } else if (!cmd_iface_.isopen()) {
+      cmd_iface_.reconnect();
+      return;
+    }
+
+    // Poll acqmode — the no-arg response includes "current mode = N"
+    reply.clear();
+    if (cmd_iface_.send_command("acqmode", reply, 200) == 0 && !reply.empty()) {
+      auto pos = reply.find("current mode = ");
+      if (pos != std::string::npos) {
+        try { state_.acqmode = std::stoi(reply.substr(pos + 15)); } catch (...) {}
+      }
+    }
+  }
+
+  void poll_acam() {
+    if (options_.acam_nbport <= 0) return;
+    if (!acam_iface_.isopen()) {
+      if (acam_iface_.open() != 0) return;
+    }
+
+    std::string reply;
+    if (acam_iface_.send_command("acquire", reply, 200) == 0 && !reply.empty()) {
+      std::string lower = to_lower_copy(reply);
+      if (lower.find("guiding") != std::string::npos) {
+        state_.guiding_on = true;
+      } else if (lower.find("stopped") != std::string::npos || lower.find("acquir") != std::string::npos) {
+        state_.guiding_on = false;
+      }
+    } else if (!acam_iface_.isopen()) {
+      acam_iface_.reconnect();
+      return;
+    }
+  }
+
+  void set_phase(int idx) {
+    if (idx < 0 || idx >= kPhaseCount) return;
+    if (state_.current_phase != idx) {
+      if (state_.current_phase >= 0 && state_.current_phase < idx) {
+        state_.phase_complete[state_.current_phase] = true;
+      }
+      for (int i = 0; i < kPhaseCount; ++i) state_.phase_active[i] = false;
+      state_.current_phase = idx;
+    }
+    state_.phase_active[idx] = true;
+  }
+
+  void clear_phase_active(int idx) {
+    if (idx < 0 || idx >= kPhaseCount) return;
+    state_.phase_active[idx] = false;
+    if (state_.current_phase == idx) {
+      state_.current_phase = -1;
+    }
+  }
+
+  void handle_waitstate(const std::string &waitstate) {
+    state_.waitstate = waitstate;
+    last_waitstate_update_ = std::chrono::steady_clock::now();
+    auto tokens = split_ws(waitstate);
+    bool has_tcsop = has_token(tokens, "TCSOP");
+    bool has_user = has_token(tokens, "USER");
+    bool has_acquire = has_token(tokens, "ACQUIRE");
+    bool has_guide = has_token(tokens, "GUIDE");
+    bool has_expose = has_token(tokens, "EXPOSE");
+    bool has_readout = has_token(tokens, "READOUT");
+
+    state_.waiting_for_tcsop = has_tcsop;
+    state_.waiting_for_user = has_user;
+    if (has_user) {
+      request_snapshot();
+    }
+
+    if (!has_tcsop && (has_acquire || has_guide || has_expose || has_readout || has_user)) {
+      state_.ontarget = true;
+    }
+
+    if (has_tcsop) {
+      set_phase(PHASE_SLEW);
+      state_.ontarget = false;
+    } else if (state_.prev_wait_tcsop && !has_tcsop) {
+      state_.phase_complete[PHASE_SLEW] = true;
+      clear_phase_active(PHASE_SLEW);
+    }
+
+    if (has_acquire || has_guide) {
+      set_phase(PHASE_SOLVE);
+    }
+    if (has_expose) {
+      set_phase(PHASE_EXPOSE);
+    }
+    if (has_readout) {
+      state_.phase_complete[PHASE_EXPOSE] = true;
+      clear_phase_active(PHASE_EXPOSE);
+    }
+
+    state_.prev_wait_tcsop = has_tcsop;
+    state_.prev_wait_guide = has_guide;
+  }
+
+  void handle_message(const std::string &raw) {
+    std::string msg = trim_copy(raw);
+    if (starts_with_local(msg, "SEQSTATE:")) {
+      std::string prev_state = state_.seqstate;
+      state_.seqstate = trim_copy(msg.substr(9));
+      last_seqstate_update_ = std::chrono::steady_clock::now();
+      auto is_ready_only = [](const std::string &s) {
+        auto tokens = split_state_tokens(s);
+        const bool has_ready = has_token(tokens, "READY");
+        const bool has_notready = has_token(tokens, "NOTREADY") || (has_token(tokens, "NOT") && has_ready);
+        if (!has_ready || has_notready) return false;
+        if (has_token(tokens, "RUNNING")) return false;
+        if (has_token(tokens, "STARTING")) return false;
+        if (has_token(tokens, "STOPPING")) return false;
+        if (has_token(tokens, "PAUSED")) return false;
+        return true;
+      };
+      if (is_ready_only(state_.seqstate) && !is_ready_only(prev_state)) {
+        std::string keep_state = state_.seqstate;
+        state_.reset();
+        state_.seqstate = keep_state;
+      }
+    } else if (starts_with_local(msg, "WAITSTATE:")) {
+      handle_waitstate(trim_copy(msg.substr(10)));
+    } else if (starts_with_local(msg, "TARGETSTATE:")) {
+      std::string upper = to_upper_copy(msg);
+      int obsid = -1;
+      auto pos = upper.find("OBSID:");
+      if (pos != std::string::npos) {
+        try {
+          obsid = std::stoi(upper.substr(pos + 6));
+        } catch (...) {
+        }
+      }
+      if (obsid > 0 && state_.current_obsid != obsid) {
+        state_.reset_progress_only();
+        state_.current_obsid = obsid;
+      }
+      auto state_pos = upper.find("TARGETSTATE:");
+      if (state_pos != std::string::npos) {
+        std::string rest = upper.substr(state_pos + 12);
+        rest = trim_copy(rest);
+        auto space = rest.find(' ');
+        std::string tstate = (space == std::string::npos) ? rest : rest.substr(0, space);
+        if (!tstate.empty() && tstate != state_.current_target_state) {
+          if (tstate == "ACTIVE" || tstate == "COMPLETE" || tstate == "PENDING") {
+            state_.reset_progress_only();
+          }
+          state_.current_target_state = tstate;
+        }
+      }
+    }
+  }
+};
+
+int main(int argc, char **argv) {
+  std::signal(SIGPIPE, SIG_IGN);
+  Options opt = parse_args(argc, argv);
+  if (opt.config_path.empty()) {
+    opt.config_path = default_config_path();
+  }
+  if (opt.acam_config_path.empty()) {
+    opt.acam_config_path = default_acam_config_path();
+  }
+  if (opt.acam_host.empty()) {
+    opt.acam_host = opt.host;
+  }
+
+  load_config(opt.config_path, opt);
+  load_acam_config(opt.acam_config_path, opt);
+
+  if (opt.nbport <= 0) {
+    std::cerr << "ERROR: NBPORT not set (check sequencerd.cfg)\n";
+    return 1;
+  }
+  if (opt.sub_endpoint.empty()) {
+    std::cerr << "WARNING: SUB_ENDPOINT not set; seq-progress will run in polling-only mode\n";
+  }
+
+  SeqProgressGui gui(opt);
+  if (!gui.init()) {
+    return 1;
+  }
+  gui.run();
+  return 0;
+}

--- a/utils/seq_progress_gui.cpp
+++ b/utils/seq_progress_gui.cpp
@@ -272,8 +272,7 @@ class SeqProgressGui {
  public:
   SeqProgressGui(const Options &opt)
       : options_(opt),
-        cmd_iface_("sequencer", options_.host, static_cast<uint16_t>(options_.nbport)),
-        acam_iface_("acam", options_.acam_host, static_cast<uint16_t>(options_.acam_nbport)) {}
+        cmd_iface_("sequencer", options_.host, static_cast<uint16_t>(options_.nbport)) {}
 
   bool init() {
     display_ = XOpenDisplay(nullptr);
@@ -302,16 +301,6 @@ class SeqProgressGui {
 
     init_zmq();
 
-    if (options_.nbport > 0) {
-      if (cmd_iface_.open() == 0) {
-        cmd_iface_.send_command("state");
-        cmd_iface_.send_command("wstate");
-      }
-    }
-    if (options_.acam_nbport > 0) {
-      acam_iface_.open();
-    }
-
     return true;
   }
 
@@ -327,6 +316,15 @@ class SeqProgressGui {
       FD_ZERO(&fds);
       FD_SET(xfd, &fds);
       int maxfd = xfd;
+
+      int zmq_fd = -1;
+      if (zmq_sub_) {
+        zmq_fd = zmq_sub_->get_fd();
+        if (zmq_fd >= 0) {
+          FD_SET(zmq_fd, &fds);
+          if (zmq_fd > maxfd) maxfd = zmq_fd;
+        }
+      }
 
       struct timeval tv;
       tv.tv_sec = 0;
@@ -384,7 +382,6 @@ class SeqProgressGui {
 
   Options options_;
   Network::Interface cmd_iface_;
-  Network::Interface acam_iface_;
   zmqpp::context zmq_context_;
   std::unique_ptr<Common::PubSub> zmq_sub_;
   std::unique_ptr<Common::PubSub> zmq_pub_;
@@ -393,8 +390,6 @@ class SeqProgressGui {
   std::chrono::steady_clock::time_point last_zmq_waitstate_;
   std::chrono::steady_clock::time_point last_zmq_any_;
   std::chrono::steady_clock::time_point last_snapshot_request_;
-  std::chrono::steady_clock::time_point last_acam_poll_;
-  std::chrono::steady_clock::time_point last_seq_poll_;
   std::chrono::steady_clock::time_point last_seqstate_update_;
   std::chrono::steady_clock::time_point last_waitstate_update_;
 
@@ -768,7 +763,7 @@ class SeqProgressGui {
     const bool has_starting = has_token(seq_tokens, "STARTING");
     const bool has_stopping = has_token(seq_tokens, "STOPPING");
     const bool have_zmq = (zmq_sub_ != nullptr);
-    const int stale_ms = have_zmq ? 5000 : (options_.poll_ms > 0 ? options_.poll_ms * 2 : 5000);
+    const int stale_ms = have_zmq ? 15000 : (options_.poll_ms > 0 ? options_.poll_ms * 2 : 5000);
     const bool seq_stale = is_stale(last_seqstate_update_, stale_ms);
     const bool wait_stale = is_stale(last_waitstate_update_, stale_ms);
 
@@ -839,10 +834,14 @@ class SeqProgressGui {
 
   bool process_zmq() {
     if (!zmq_sub_) return false;
-    if (!zmq_sub_->has_message()) return false;
-    auto [topic, payload] = zmq_sub_->receive();
-    handle_zmq_message(topic, payload);
-    return true;
+    constexpr int kMaxDrainPerCycle = 50;
+    int count = 0;
+    while (count < kMaxDrainPerCycle && zmq_sub_->has_message_nonblock()) {
+      auto [topic, payload] = zmq_sub_->receive();
+      handle_zmq_message(topic, payload);
+      ++count;
+    }
+    return count > 0;
   }
 
   void handle_zmq_message(const std::string &topic, const std::string &payload) {
@@ -972,11 +971,14 @@ class SeqProgressGui {
 
   void request_snapshot() {
     if (!zmq_pub_) return;
+    auto now = std::chrono::steady_clock::now();
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - last_snapshot_request_).count() < 5000) return;
     nlohmann::json jmessage;
     jmessage["sequencerd"] = true;
     jmessage["acamd"] = true;
     zmq_pub_->publish(jmessage, "_snapshot");
-    last_snapshot_request_ = std::chrono::steady_clock::now();
+    last_snapshot_request_ = now;
   }
 
   bool is_stale(const std::chrono::steady_clock::time_point &tp, int stale_ms) const {
@@ -985,118 +987,26 @@ class SeqProgressGui {
     return std::chrono::duration_cast<std::chrono::milliseconds>(now - tp).count() > stale_ms;
   }
 
-  bool should_poll_acam() const {
-    if (state_.seqstate.find("RUNNING") != std::string::npos) return true;
-    if (state_.waitstate.find("ACQUIRE") != std::string::npos) return true;
-    if (state_.waitstate.find("GUIDE") != std::string::npos) return true;
-    if (state_.waitstate.find("EXPOSE") != std::string::npos) return true;
-    if (state_.waitstate.find("READOUT") != std::string::npos) return true;
+  bool maybe_poll(const std::chrono::steady_clock::time_point &now) {
+    if (!zmq_sub_ || !zmq_pub_) return false;
+
+    constexpr int kSnapshotIntervalMs = 15000;
+    constexpr int kStaleThresholdMs   = 10000;
+
+    const bool seq_stale = is_stale(last_zmq_seqstate_, kStaleThresholdMs) ||
+                           is_stale(last_zmq_waitstate_, kStaleThresholdMs);
+
+    auto ms_since_snapshot = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now - last_snapshot_request_).count();
+
+    if (seq_stale && ms_since_snapshot >= kSnapshotIntervalMs) {
+      request_snapshot();
+      return true;
+    }
     return false;
   }
 
-  bool maybe_poll(const std::chrono::steady_clock::time_point &now) {
-    bool updated = false;
-    const int stale_ms = 5000;
-    const bool have_zmq = (zmq_sub_ != nullptr);
-    const bool stale_seq = have_zmq &&
-                           (is_stale(last_zmq_seqstate_, stale_ms) ||
-                            is_stale(last_zmq_waitstate_, stale_ms));
-    const bool zmq_quiet = have_zmq && is_stale(last_zmq_any_, options_.poll_ms > 0 ? options_.poll_ms * 3 : stale_ms * 3);
-    const bool allow_tcp_poll = !have_zmq || (zmq_quiet && stale_seq);
 
-    if (options_.poll_ms > 0) {
-      if (have_zmq && zmq_pub_ && state_.waiting_for_user &&
-          std::chrono::duration_cast<std::chrono::milliseconds>(now - last_snapshot_request_).count() >= 1000) {
-        request_snapshot();
-        updated = true;
-      }
-      if (have_zmq && zmq_pub_) {
-        if (stale_seq &&
-            std::chrono::duration_cast<std::chrono::milliseconds>(now - last_snapshot_request_).count() >= stale_ms) {
-          request_snapshot();
-          updated = true;
-        }
-      }
-      if (allow_tcp_poll) {
-        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_seq_poll_).count() >= options_.poll_ms) {
-          poll_sequencer();
-          last_seq_poll_ = now;
-          updated = true;
-        }
-        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_acam_poll_).count() >= options_.poll_ms) {
-          if (should_poll_acam()) {
-            poll_acam();
-            updated = true;
-          }
-          last_acam_poll_ = now;
-        }
-      }
-    } else if (have_zmq && zmq_pub_) {
-      if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_snapshot_request_).count() >= stale_ms) {
-        request_snapshot();
-        updated = true;
-      }
-    }
-
-    return updated;
-  }
-
-  void poll_status() {
-    poll_sequencer();
-    poll_acam();
-  }
-
-  void poll_sequencer() {
-    if (options_.nbport <= 0) return;
-    if (!cmd_iface_.isopen()) {
-      if (cmd_iface_.open() != 0) return;
-    }
-
-    std::string reply;
-    if (cmd_iface_.send_command("state", reply, 200) == 0 && !reply.empty()) {
-      handle_message("SEQSTATE: " + reply);
-    } else if (!cmd_iface_.isopen()) {
-      cmd_iface_.reconnect();
-      return;
-    }
-
-    reply.clear();
-    if (cmd_iface_.send_command("wstate", reply, 200) == 0 && !reply.empty()) {
-      handle_waitstate(reply);
-    } else if (!cmd_iface_.isopen()) {
-      cmd_iface_.reconnect();
-      return;
-    }
-
-    // Poll acqmode — the no-arg response includes "current mode = N"
-    reply.clear();
-    if (cmd_iface_.send_command("acqmode", reply, 200) == 0 && !reply.empty()) {
-      auto pos = reply.find("current mode = ");
-      if (pos != std::string::npos) {
-        try { state_.acqmode = std::stoi(reply.substr(pos + 15)); } catch (...) {}
-      }
-    }
-  }
-
-  void poll_acam() {
-    if (options_.acam_nbport <= 0) return;
-    if (!acam_iface_.isopen()) {
-      if (acam_iface_.open() != 0) return;
-    }
-
-    std::string reply;
-    if (acam_iface_.send_command("acquire", reply, 200) == 0 && !reply.empty()) {
-      std::string lower = to_lower_copy(reply);
-      if (lower.find("guiding") != std::string::npos) {
-        state_.guiding_on = true;
-      } else if (lower.find("stopped") != std::string::npos || lower.find("acquir") != std::string::npos) {
-        state_.guiding_on = false;
-      }
-    } else if (!acam_iface_.isopen()) {
-      acam_iface_.reconnect();
-      return;
-    }
-  }
 
   void set_phase(int idx) {
     if (idx < 0 || idx >= kPhaseCount) return;
@@ -1131,9 +1041,6 @@ class SeqProgressGui {
 
     state_.waiting_for_tcsop = has_tcsop;
     state_.waiting_for_user = has_user;
-    if (has_user) {
-      request_snapshot();
-    }
 
     if (!has_tcsop && (has_acquire || has_guide || has_expose || has_readout || has_user)) {
       state_.ontarget = true;
@@ -1234,8 +1141,7 @@ int main(int argc, char **argv) {
   load_acam_config(opt.acam_config_path, opt);
 
   if (opt.nbport <= 0) {
-    std::cerr << "ERROR: NBPORT not set (check sequencerd.cfg)\n";
-    return 1;
+    std::cerr << "WARNING: NBPORT not set; ontarget/usercontinue buttons will be disabled\n";
   }
   if (opt.sub_endpoint.empty()) {
     std::cerr << "WARNING: SUB_ENDPOINT not set; seq-progress will run in polling-only mode\n";

--- a/utils/seq_progress_gui.cpp
+++ b/utils/seq_progress_gui.cpp
@@ -890,7 +890,10 @@ class SeqProgressGui {
           }
         }
         if (jmessage.contains("ontarget") && jmessage["ontarget"].is_boolean()) {
-          state_.ontarget = jmessage["ontarget"].get<bool>();
+          // Latch ontarget=true; only clear on new target (reset_progress_only above)
+          if (jmessage["ontarget"].get<bool>()) {
+            state_.ontarget = true;
+          }
         }
         if (jmessage.contains("fine_tune_active") && jmessage["fine_tune_active"].is_boolean()) {
           bool active = jmessage["fine_tune_active"].get<bool>();


### PR DESCRIPTION
## Summary

- Implement three acquisition automation modes (`MANUAL`, `AUTOMATIC`, `FULL_AUTOMATIC`) controlled via the new `acqmode` command, enabling configurable hands-off target acquisition
- Integrate `ngps_acq` fine-acquisition algorithm in slicecamd (source detection, centroiding, TCS offsets, closed-loop acquisition) via C callback API
- Publish ACAM guiding/acquiring state and preserve guiding during offsets
- Add `seq_progress_gui` (X11+ZMQ) for real-time observation phase display (SLEW/SOLVE/FINE/OFFSET/EXPOSE)
- Add configuration parameters for acquisition timeouts and fine-tune settings

## Files changed (19)

**New files (4):** `slicecamd/ngps_acq.c`, `common/ngps_acq_embed.h`, `utils/seq_progress_gui.cpp`, `common/message_keys.h`, `run/seq-progress`

**Modified files (14):** `sequencerd/sequence.cpp`, `slicecamd/slicecam_interface.cpp`, `sequencerd/sequence.h`, `sequencerd/sequencer_server.cpp`, `slicecamd/slicecam_interface.h`, `Config/sequencerd.cfg.in`, `Config/slicecamd.cfg.in`, `acamd/acam_interface.cpp`, `utils/CMakeLists.txt`, `slicecamd/CMakeLists.txt`, `common/sequencerd_commands.h`, `common/slicecamd_commands.h`, `sequencerd/sequencerd.cpp`, `slicecamd/slicecam_server.cpp`

## Test plan

- [ ] Build with `cmake .. && make -j$(nproc)` — verify all 19 files compile cleanly
- [ ] Verify `acqmode` command accepts MANUAL/AUTOMATIC/FULL_AUTOMATIC
- [ ] Test acquisition state machine transitions: SLEW → SOLVE → FINE → OFFSET → EXPOSE
- [ ] Verify seq_progress_gui launches and displays phase updates via ZMQ
- [ ] Test fine-acquisition loop with slicecam source detection and TCS offsets
- [ ] Confirm ACAM guiding state is preserved during offset_goal operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)