### PR TITLE
adds missing shutter function to slicecamd

### DIFF
--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -2480,6 +2480,48 @@ namespace Slicecam {
   /***** Slicecam::Interface::shutdown ****************************************/
 
 
+  /***** Slicecam::Interface::shutter *****************************************/
+  /**
+   * @brief      get/set shutter
+   * @param[in]  args       [open|close|auto]
+   * @param[out] retstring  return string
+   * @return     ERROR | NO_ERROR | HELP
+   *
+   */
+  long Interface::shutter(const std::string args, std::string &retstring) {
+    const std::string function("Slicecam::Interface::shutter");
+
+    // Help
+    if ( args == "?" || args == "help" ) {
+      retstring = SLICECAMD_SHUTTER;
+      retstring.append( " [ open | close | auto]\n" );
+      retstring.append( "   open or close the internal shutter\n" );
+      retstring.append( "   applies to all connected cameras\n" );
+      return HELP;
+    }
+
+    // if it's not empty then it must be open|close|auto
+    if (!args.empty() && (args != "open" && args != "close" && args != "auto")) {
+      logwrite(function, "ERROR expected [ open | close | auto ]");
+      retstring="invalid_argument";
+      return ERROR;
+    }
+
+    long error = NO_ERROR;
+
+    std::ostringstream oss;
+    for (const auto &pair : this->camera.andor) {
+      std::string state = args;
+      error |= pair.second->set_shutter(state);
+      oss << pair.second->camera_info.camera_name << ":" << state << " ";
+    }
+    retstring=oss.str();
+
+    return error;
+  }
+  /***** Slicecam::Interface::shutter *****************************************/
+
+
   /***** Slicecam::Interface::test ********************************************/
   /**
    * @brief      test routines

--- a/slicecamd/slicecam_interface.h
+++ b/slicecamd/slicecam_interface.h
@@ -365,6 +365,7 @@ namespace Slicecam {
       long gui_settings_control();          /// get gui settings and push to Guider GUI display
       long gui_settings_control( std::string args, std::string &retstring );  /// set or get and push to Guider GUI display
       long shutdown( std::string args, std::string &retstring );
+      long shutter(const std::string args, std::string &retstring);
       long test( std::string args, std::string &retstring );
       long exptime( std::string args, std::string &retstring );
       long fan_mode( std::string args, std::string &retstring );

--- a/slicecamd/slicecam_server.cpp
+++ b/slicecamd/slicecam_server.cpp
@@ -594,6 +594,10 @@ namespace Slicecam {
                       ret = NO_ERROR;  // init_names() returns void, never fails
       }
       else
+      if ( cmd == SLICECAMD_SHUTTER ) {
+                      ret = this->interface.shutter(args, retstring);
+      }
+      else
 
       // shutdown
       //


### PR DESCRIPTION
why now? because they are trying to debug a problem with one of the slice cameras and want to be able to hear if the shutter is opening/closing.