### PR TITLE
critical bug fix for CAL_ targets

### DIFF
--- a/sequencerd/sequence.cpp
+++ b/sequencerd/sequence.cpp
@@ -168,6 +168,28 @@ namespace Sequencer {
   /***** Sequencer::Sequence::publish_snapshot *******************************/
 
 
+  /***** Sequencer::Sequence::request_snapshot *******************************/
+  /**
+   * @brief      asks subscribed daemons to re-publish their current telemetry
+   * @details    Publishes a SNAPSHOT request listing each daemon whose topic
+   *             this sequencer subscribes to. Each named daemon responds by
+   *             re-publishing its own state, ensuring the sequencer receives
+   *             current telemetry even if the daemon published before the
+   *             sequencer subscribed.
+   *
+   */
+  void Sequence::request_snapshot() {
+    nlohmann::json jmessage;
+    jmessage[Daemon::CAMERAD]   = true;
+    jmessage[Daemon::ACAMD]     = true;
+    jmessage[Daemon::SLICECAMD] = true;
+    jmessage[Daemon::SLITD]     = true;
+    jmessage[Daemon::TCSD]      = true;
+    this->publisher->publish( jmessage, Topic::SNAPSHOT );
+  }
+  /***** Sequencer::Sequence::request_snapshot *******************************/
+
+
   /***** Sequencer::Sequence::publish_seqstate ********************************/
   /**
    * @brief      publishes sequencer state under Topic::SEQ_SEQSTATE
@@ -2026,6 +2048,10 @@ namespace Sequencer {
     const std::string function("Sequencer::Sequence::move_to_target");
     std::stringstream message;
     long error=NO_ERROR;
+
+    // no telescope moves for calibration targets
+    //
+    if ( this->target.iscal ) return NO_ERROR;
 
     ScopedState thr_state( thread_state_manager, Sequencer::THR_MOVE_TO_TARGET );
     ScopedState wait_state( wait_state_manager, Sequencer::SEQ_WAIT_TCS );

--- a/sequencerd/sequence.h
+++ b/sequencerd/sequence.h
@@ -491,6 +491,7 @@ namespace Sequencer {
       void handletopic_slitd( const nlohmann::json &jmessage );
       void handletopic_tcsd( const nlohmann::json &jmessage );
       void publish_snapshot();
+      void request_snapshot();
       void publish_seqstate();
       void publish_waitstate();
       void publish_daemonstate();

--- a/sequencerd/sequencerd.cpp
+++ b/sequencerd/sequencerd.cpp
@@ -141,6 +141,7 @@ int main(int argc, char **argv) {
 
   std::this_thread::sleep_for( std::chrono::milliseconds(200) );
   sequencerd.sequence.publish_snapshot();
+  sequencerd.sequence.request_snapshot();
 
   // This will pre-thread N_THREADS threads.
   // The 0th thread is reserved for the blocking port, and the rest are for the non-blocking port.


### PR DESCRIPTION
_critical bug fixes_

While testing CAL_ target list today, TCS move was requested -- CAL target should not request TCS move.
Exposure was not started because sequencerd didn't have camerad's published status.
An abort resulted in the wrong state.

This fixes all three problems.