### PR TITLE
bug fix: reset fineacquire flags and publish in slicecamd

### DIFF
--- a/acamd/acam_server.cpp
+++ b/acamd/acam_server.cpp
@@ -58,6 +58,8 @@ namespace Acam {
    *
    */
   void Server::exit_cleanly(void) {
+    std::string dontcare;
+    Server::instance->interface.acquire( "stop", dontcare );
     Server::instance->interface.close();
     Server::instance->interface.stop_subscriber_thread();
     logwrite( "Acam::Server::exit_cleanly", "exiting" );

--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -1586,6 +1586,9 @@ namespace Slicecam {
     } while ( this->should_framegrab_run.load(std::memory_order_acquire) );
     }
 
+    this->is_fineacquire_running.store( false, std::memory_order_release );
+    this->is_fineacquire_locked.store(  false, std::memory_order_release );
+    this->publish_status();
     this->cv.notify_all();  // send notification that the loop has stopped
 
     if ( error != NO_ERROR ) {


### PR DESCRIPTION
_this bug affects all branches_
and caused any subscriber to indicate acquisition still on after a shutdown.

bug fix: reset fineacquire flags and publish in slicecamd
also publish acamd/slicecamd state on exit
and make sure acam stops before exit