### PR TITLE
critical bug fix:waiting for camera

### DIFF
--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -62,7 +62,7 @@ namespace AstroCam {
    *
    */
   void Interface::handletopic_snapshot( const nlohmann::json &jmessage_in ) {
-    if ( jmessage_in.contains( Topic::CAMERAD ) ) this->publish_status();
+    if ( jmessage_in.contains( Topic::CAMERAD ) ) this->publish_status(true);
   }
   /***** AstroCam::Interface::handletopic_snapshot ****************************/
 

--- a/common/common.h
+++ b/common/common.h
@@ -211,11 +211,11 @@ namespace Common {
           return ERROR;
         }
 
-        // Initialize the message subscriber. All daemons minimally subscribe to "_snapshot"
+        // Initialize the message subscriber. All daemons minimally subscribe to Topic::SNAPSHOT
         // which causes them to publish their current status.
         //
         iface.subscriber_topics.clear();
-        iface.subscriber_topics.push_back("_snapshot");
+        iface.subscriber_topics.push_back(Topic::SNAPSHOT);
 
         for ( const auto &topic : topics ) {
           iface.subscriber_topics.push_back(topic);

--- a/sequencerd/sequence.cpp
+++ b/sequencerd/sequence.cpp
@@ -465,16 +465,6 @@ namespace Sequencer {
                                                 {Sequencer::SEQ_WAIT_EXPOSE} );     // clear EXPOSE
         }
 
-        // ---------------------------------------------
-        // clear READOUT flag on the end-of-frame signal
-        // ---------------------------------------------
-        //
-        if ( statstr.compare( 0, 10, "FRAMECOUNT" ) == 0 ) {                        // async message tag FRAMECOUNT
-          if ( seq.wait_state_manager.is_set( Sequencer::SEQ_WAIT_READOUT ) ) {
-            seq.wait_state_manager.clear( Sequencer::SEQ_WAIT_READOUT );
-          }
-        }
-
         // ---------------------
         // process TEST messages
         // ---------------------
@@ -825,15 +815,19 @@ namespace Sequencer {
                                << " id " << this->target.obsid << " order " << this->target.obsorder;
       logwrite( function, message.str() );
 
-      // If not using frame transfer then wait for readout, too
+      // Wait for all N exposures to complete across all active channels.
+      // camerad publishes can_expose=true (READY key) only after the last channel
+      // of the last exposure finishes — the correct completion signal for both
+      // single and multi-exposure sequences. Skip the wait for frame transfer.
       //
       if (!this->is_science_frame_transfer) {
         logwrite( function, "waiting for readout" );
-        while ( !this->cancel_flag.load() && wait_state_manager.is_set( Sequencer::SEQ_WAIT_READOUT ) ) {
-          std::unique_lock<std::mutex> lock(cv_mutex);
-          this->cv.wait( lock, [this]() { return( !wait_state_manager.is_set(SEQ_WAIT_READOUT) || this->cancel_flag.load() ); } );
-        }
+        std::unique_lock<std::mutex> lock(this->camerad_mtx);
+        this->camerad_cv.wait( lock, [this]() {
+          return this->can_expose.load() || this->cancel_flag.load();
+        } );
       }
+      this->wait_state_manager.clear( Sequencer::SEQ_WAIT_READOUT );
 
       // Now that we're done waiting, check for errors or abort
       //

--- a/sequencerd/sequencerd.cpp
+++ b/sequencerd/sequencerd.cpp
@@ -139,8 +139,9 @@ int main(int argc, char **argv) {
   }
   sequencerd.sequence.seq_state_manager.set_only({Sequencer::SEQ_NOTREADY});
 
-  std::this_thread::sleep_for( std::chrono::milliseconds(200) );
+  std::this_thread::sleep_for( std::chrono::milliseconds(250) );
   sequencerd.sequence.publish_snapshot();
+  std::this_thread::sleep_for( std::chrono::milliseconds(250) );
   sequencerd.sequence.request_snapshot();
 
   // This will pre-thread N_THREADS threads.


### PR DESCRIPTION
fix: sequencerd stuck on `waiting for camera`
With `expose N` for N>1, using UDP broadcast to determine
camera ready was broken. Use instead the ZMQ PUB-SUB mechanism
already in place.
