### PR TITLE
Query ACAM directly for guide state in "put on slit" routing

### DIFF
--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -2507,7 +2507,21 @@ namespace Slicecam {
     // If ACAM is guiding then slicecam must not move the telescope,
     // but must allow ACAM to perform the offset.
     //
-    bool is_guiding = this->is_acam_guiding.load();
+    // Ask acamd directly for its guide state instead of trusting the cached
+    // pub/sub flag (is_acam_guiding). ACAM publishes its status only on change
+    // and skips frames between solves, so the cache can read "guiding" while
+    // stale or lag a state change. Routing on a wrong "not guiding" would send
+    // a PT offset and move the telescope while ACAM is actively guiding; a
+    // wrong "guiding" would send a no-op offsetgoal and never move. A direct
+    // query is authoritative and current. ACAMD_ACQUIRE with no args returns
+    // the mode string { stopped | acquiring | guiding }.
+    //
+    std::string acam_mode;
+    if ( this->acamd.command( ACAMD_ACQUIRE, acam_mode ) != NO_ERROR ) {
+      logwrite( function, "ERROR querying ACAM guide state" );
+      return ERROR;
+    }
+    bool is_guiding = ( acam_mode.find("guiding") != std::string::npos );
 
     // send the offsets now
     //


### PR DESCRIPTION
## Problem

"Put on slit" intermittently fails when guiding is **off** — the telescope doesn't move and the command silently does nothing.

The decision is made inside the daemon: `putonslit.sh` only reads ds9 coordinates and sends one `scam putonslit`. slicecam's `offset_acam_goal()` then routes between **updating ACAM's guide goal** (guiding) and **sending a PT offset directly to the TCS** (not guiding), based on a cached `is_acam_guiding` flag populated from ACAM's pub/sub status.

## Root cause — the cached guide state can be wrong

ACAM publishes its status **only on change**, and the frame loop **skips frames** between solves (`if (_skipframes-- > 0) continue;`). So the cached flag can read "guiding" while stale, or lag a state change. Trusting it for this decision is unsafe **in both directions**:

- a wrong **"not guiding"** → sends a PT offset and **moves the telescope while ACAM is actively guiding** (fights the guider);
- a wrong **"guiding"** → sends a no-op `offsetgoal` and never moves ("put on slit didn't work").

## Fix (minimal)

Query acamd **directly** for its guide state at decision time instead of trusting the cache. `ACAMD_ACQUIRE` with no args returns the current mode `{ stopped | acquiring | guiding }` — authoritative and current — so the routing no longer depends on pub/sub freshness.

Single-file change in `slicecam_interface.cpp::offset_acam_goal`.

> Note: an earlier version of this PR added a per-frame ACAM heartbeat plus a freshness guard. Codex correctly pointed out that a freshness cache fundamentally cannot distinguish "guiding but stale" from "not guiding" (skipframes, long exposures, solver/pub-sub delays all lapse freshness while guiding), so it could still move the telescope during active guiding. That approach was dropped in favor of the direct query.

Not compiled locally (no local build available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)