### PR TITLE
Align slicecam fine-acquisition with the proven auto-acq-clean engine

### DIFF
--- a/Config/slicecamd.cfg.in
+++ b/Config/slicecamd.cfg.in
@@ -84,17 +84,32 @@ FINE_ACQUIRE_BACKGROUND=(80 165 30 210)
 #
 FINE_ACQUIRE_MIN_SAMPLES=3
 
+# FINE_ACQUIRE_PREC=<arcsec>
+# MAD scatter threshold per axis (arcsec). A correction is only commanded when
+# the per-axis scatter of the collected samples is within this; a noisier batch
+# is discarded and re-gathered rather than moving on an untrustworthy median.
+#
+FINE_ACQUIRE_PREC=0.4
+
 # FINE_ACQUIRE_SETTLE_FRAMES=<n>
 # <n> frames discarded after each telescope move to allow settling before
 # centroid measurements resume.
 #
 FINE_ACQUIRE_SETTLE_FRAMES=2
 
-# FINE_ACQUIRE_GAIN=<g>
-# Proportional gain <g> = {0..1} applied to the commanded offset when the residual
-# is at or below FINE_ACQUIRE_GAIN_THRESHOLD arcsec.
+# FINE_ACQUIRE_SETTLE_SEC=<sec>
+# Seconds to wait after a commanded telescope move before evaluating the next
+# frame. The move plus CCD readout takes time; acting on a frame grabbed mid-
+# move/mid-settle gives a wrong correction. Time-based, independent of cadence.
 #
-FINE_ACQUIRE_GAIN=0.7
+FINE_ACQUIRE_SETTLE_SEC=4
+
+# FINE_ACQUIRE_GAIN=<g>
+# Proportional gain <g> applied to the commanded offset. Use 1.0: a fine-tune
+# step should apply the full measured offset -- deliberately under-correcting a
+# known offset is never beneficial here.
+#
+FINE_ACQUIRE_GAIN=1.0
 
 # FINE_ACQUIRE_GAIN_LARGE=<g>
 # Proportional gain <g> applied when the residual exceeds FINE_ACQUIRE_GAIN_THRESHOLD.

--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -269,6 +269,13 @@ namespace Slicecam {
   void Interface::do_fineacquire() {
     const char* function = "Slicecam::Interface::do_fineacquire";
 
+    // After commanding a TCS move, wait settle_sec before evaluating another
+    // frame. The move plus CCD readout takes time; acting on an image grabbed
+    // mid-move or mid-settle yields a wrong correction. Time-based so it does
+    // not depend on the frame cadence.
+    //
+    if ( std::chrono::steady_clock::now() < this->fineacquire_state.settle_until ) return;
+
     // skip frames if we are waiting for the telescope to settle after a move
     //
     if (this->fineacquire_state.settle_frames > 0) {
@@ -300,6 +307,21 @@ namespace Slicecam {
     if (img_data.empty()) {
       logwrite(function, "no image data for slicecam '"+which+"'");
       return;
+    }
+
+    // Reject a duplicate frame. A commanded framegrab does not guarantee the
+    // image has refreshed; processing the same frame twice double-counts
+    // samples and can command a second move from a pre-move image (overshoot).
+    // Skip the frame if a cheap subsample signature matches the last one.
+    //
+    {
+      uint64_t sig = 1469598103934665603ULL;  // FNV-1a offset basis
+      const size_t step = img_data.size() > 4096 ? img_data.size() / 4096 : 1;
+      for ( size_t i = 0; i < img_data.size(); i += step ) {
+        sig = ( sig ^ static_cast<uint64_t>( static_cast<int64_t>( img_data[i] ) ) ) * 1099511628211ULL;
+      }
+      if ( sig == this->fineacquire_state.last_frame_sig ) return;  // identical frame; wait for a fresh one
+      this->fineacquire_state.last_frame_sig = sig;
     }
 
     // find the star centroid near the aim point
@@ -514,6 +536,21 @@ namespace Slicecam {
       }
     }
 
+    // Never command a move from a noisy solution. We reach here either with the
+    // scatter within tolerance, or because we hit max_samples. In the latter
+    // case, if the scatter is still too high the median is not trustworthy:
+    // discard the batch and re-gather rather than applying a full-gain move to
+    // an unreliable position (which causes wrong/overshooting moves). This
+    // matches the reference engine, which refuses to move until precision is met.
+    //
+    if ( !scatter_ok ) {
+      logwrite( function, "fine acquisition: scatter too high to move safely after "
+                +std::to_string(n)+" samples (scatter=("+std::to_string(sig_dra)+","
+                +std::to_string(sig_ddec)+") > "+std::to_string(prec)+" arcsec); re-gathering" );
+      this->fineacquire_state.reset();
+      return;
+    }
+
     // select gain: use gain_large when offset is well above the goal threshold
     //
     const double effective_gain = ( offset_arcsec > this->fineacquire_state.gain_threshold_arcsec )
@@ -542,9 +579,13 @@ namespace Slicecam {
       return;
     }
 
-    // reset samples and discard settle_count frames for telescope settling
+    // reset samples; ignore frames for settle_count frames AND for settle_sec
+    // seconds so the telescope move + readout completes before we measure again
     this->fineacquire_state.reset();
     this->fineacquire_state.settle_frames = this->fineacquire_state.settle_count;
+    this->fineacquire_state.settle_until  = std::chrono::steady_clock::now()
+      + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+          std::chrono::duration<double>( this->fineacquire_state.settle_sec ) );
   }
   /***** Slicecam::Interface::do_fineacquire **********************************/
 
@@ -1362,6 +1403,32 @@ namespace Slicecam {
         try { this->fineacquire_state.gain_threshold_arcsec = std::stod( config.arg[entry] ); }
         catch ( const std::exception &e ) {
           message.str(""); message << "ERROR invalid FINE_ACQUIRE_GAIN_THRESHOLD "
+                                   << config.arg[entry] << ": " << e.what();
+          logwrite( function, message.str() );
+          return ERROR;
+        }
+        message.str(""); message << "SLICECAMD:config:" << config.param[entry] << "=" << config.arg[entry];
+        logwrite( function, message.str() );
+        applied++;
+      }
+
+      if ( config.param[entry] == "FINE_ACQUIRE_PREC" ) {
+        try { this->fineacquire_state.prec_arcsec = std::stod( config.arg[entry] ); }
+        catch ( const std::exception &e ) {
+          message.str(""); message << "ERROR invalid FINE_ACQUIRE_PREC "
+                                   << config.arg[entry] << ": " << e.what();
+          logwrite( function, message.str() );
+          return ERROR;
+        }
+        message.str(""); message << "SLICECAMD:config:" << config.param[entry] << "=" << config.arg[entry];
+        logwrite( function, message.str() );
+        applied++;
+      }
+
+      if ( config.param[entry] == "FINE_ACQUIRE_SETTLE_SEC" ) {
+        try { this->fineacquire_state.settle_sec = std::stod( config.arg[entry] ); }
+        catch ( const std::exception &e ) {
+          message.str(""); message << "ERROR invalid FINE_ACQUIRE_SETTLE_SEC "
                                    << config.arg[entry] << ": " << e.what();
           logwrite( function, message.str() );
           return ERROR;

--- a/slicecamd/slicecam_interface.h
+++ b/slicecamd/slicecam_interface.h
@@ -87,13 +87,16 @@ namespace Slicecam {
     std::vector<double> ddec_samp;  ///< dDEC samples, degrees
     int    max_samples  = 10;       ///< samples before evaluating a move
     int    min_samples  = 3;        ///< minimum samples before scatter-gated early exit
-    double prec_arcsec  = 0.1;      ///< MAD scatter threshold per axis for early exit (arcsec)
+    double prec_arcsec  = 0.4;      ///< MAD scatter threshold per axis; never command a move unless scatter is within this (arcsec)
     double goal_arcsec  = 0.3;      ///< convergence threshold, arcsec
-    double gain         = 0.7;      ///< gain applied when offset <= gain_threshold_arcsec
+    double gain         = 1.0;      ///< gain applied when offset <= gain_threshold_arcsec (full correction; never under-correct a known offset)
     double gain_large   = 1.0;      ///< gain applied when offset > gain_threshold_arcsec
     double gain_threshold_arcsec = 2.0; ///< offset above which gain_large is used
     int    settle_frames = 0;       ///< countdown of frames to discard while telescope settles
     int    settle_count  = 2;       ///< configured: frames to discard after each move
+    double settle_sec    = 4.0;     ///< configured: seconds to wait after a TCS move before evaluating the next frame
+    std::chrono::steady_clock::time_point settle_until{};  ///< frames are ignored until this time (post-move settle)
+    uint64_t last_frame_sig = 0;    ///< signature of the last processed frame, to reject duplicate (unrefreshed) frames
     int    consecutive_centroid_failures = 0; ///< counts consecutive centroid failures
     // exposure compensation (shared by the reactive trim and, later, autoexpose)
     double exptime_min     = 0.1;   ///< clamp: minimum auto-adjusted exposure (sec)

--- a/slicecamd/slicecam_math.cpp
+++ b/slicecamd/slicecam_math.cpp
@@ -185,7 +185,7 @@ namespace Slicecam {
    *             Among all qualifying candidates, select the brightest.
    *
    *             Step 4: refine to sub-pixel centroid via iterative Gaussian-
-   *             windowed first-moment (centroid_sigma_pix = 2.0, 12 iterations,
+   *             windowed first-moment (centroid_sigma_pix = 1.2, 12 iterations,
    *             eps = 0.01 px).
    *
    *             All pixel coordinates are FITS 1-based on input and output.
@@ -324,12 +324,12 @@ namespace Slicecam {
     // --- Step 4: iterative Gaussian-windowed first-moment centroid ---
     //
     // centroid_halfwin    = 4   (CF's --centroid-hw default)
-    // centroid_sigma_pix  = 2.0 (CF's default, NOTE: different from filt_sigma)
+    // centroid_sigma_pix  = 1.2 (matches auto-acq-clean --centroid-sigma 1.2)
     // centroid_maxiter    = 12  (CF's default)
     // centroid_eps_pix    = 0.01
     //
     const int    hw  = 4;
-    const double s2  = 2.0 * 2.0;  // centroid_sigma_pix^2
+    const double s2  = 1.2 * 1.2;  // centroid_sigma_pix^2
 
     double cx   = static_cast<double>( best_x );
     double cy   = static_cast<double>( best_y );


### PR DESCRIPTION
## Why behavior differs from `feature/acq-automation-clean`

main's slicecam fine-acquisition is **not the same code** as the known-good branch — it is a from-scratch C++ rewrite (`fineacquire`/`do_fineacquire`) of the proven embedded-C engine `slicecamd/ngps_acq.c` (which main deleted). The rewrite diverged in several ways that produce wrong/overshooting moves and different convergence.

This PR is the **targeted alignment (Option C)** — parameter + logic fixes to make the behavior match the reference. The reference's larger adaptive faint/bright exposure engine (EWMA modes, frame-averaging) is **out of scope** here.

## Changes

| Area | Before (main) | After (= reference) |
|---|---|---|
| **Move on noisy data** | at `max_samples`, moves anyway regardless of scatter | only move when per-axis MAD scatter ≤ `prec`; else discard & re-gather |
| **Precision gate** | `0.1″` hardcoded | `0.4″`, configurable via `FINE_ACQUIRE_PREC` |
| **Gain** | `0.7` | `1.0` — apply the full measured offset (never under-correct a known offset) |
| **Post-move settle** | skip 2 frames only | wait `FINE_ACQUIRE_SETTLE_SEC` (4 s) after a TCS move, time-based |
| **Duplicate frames** | none (can re-process a stale frame → double offset) | reject a frame whose subsample signature matches the previous |
| **Centroid σ** | `2.0` px | `1.2` px (`--centroid-sigma 1.2`) |

### The overshoot symptom
The most likely contributors to "moves wrong / overshoots" were (1) **re-processing a duplicate frame** (the framegrab file may not have refreshed) → a second move from a pre-move image, and (2) **moving on a high-scatter median**. Both are now prevented; the **4 s post-move settle** further ensures the move + readout completes before the next measurement.

### Sign / convention — verified, no change needed
Both branches measure `(star − goal)` with `cos(dec)` and `tcs_sign = +1`, and both apply via `ACAMD_OFFSETGOAL(star − goal)`. The reference reaches the identical value through `put_on_slit`→`solve_offset` (with `slit = goal`, `cross = slit + (star−goal) = star`, and `solve_offset(slit, cross) = (cross − slit) = (star − goal)`). So main's direct application has the **same sign and magnitude**; the only nuance is main's flat `cos(dec)` vs the reference's spherical solver — negligible at arcsec scale.

## Notes
- `FINE_ACQUIRE_PREC=0.4` and `FINE_ACQUIRE_SETTLE_SEC=4` added to `slicecamd.cfg.in`; members default to those values so pre-existing configs still behave correctly.
- With `gain = 1.0`, the two-tier `gain`/`gain_large` is now effectively a single full-gain step.
- Not compiled locally (no local build available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)