### PR TITLE
Sequencer: stop fineacquire on timeout; lock user moves during ACAM acquire

### DIFF
--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -5577,6 +5577,17 @@ logwrite( function, message.str() );
       return ERROR;
     }
 
+    // Lock out user-initiated moves while actively acquiring (converging on the
+    // target); a manual move would disrupt the acquisition. Allowed while
+    // guiding or stopped.
+    //
+    if ( this->target.acquire_mode == Acam::TARGET_ACQUIRE ||
+         this->target.acquire_mode == Acam::TARGET_ACQUIRE_HERE ) {
+      logwrite( function, "ERROR cannot move while ACAM is acquiring" );
+      retstring="acquiring";
+      return ERROR;
+    }
+
     std::vector<std::string> tokens;
     Tokenize( args, tokens, " " );
 

--- a/sequencerd/sequence_acquisition.cpp
+++ b/sequencerd/sequence_acquisition.cpp
@@ -178,26 +178,35 @@ namespace Sequencer {
     // before slicecamd's first telemetry publish arrives.
     //
     bool was_running = false;
-    std::unique_lock<std::mutex> lock(this->fineacquire_mtx);
-    this->fineacquire_cv.wait(lock, [&]() {
-        if ( this->is_fineacquire_running.load() ) was_running = true;
-        return this->is_fineacquire_locked.load() || this->cancel_flag.load() ||
-               ( was_running && !this->is_fineacquire_running.load() ) ||
-               (use_timeout && std::chrono::steady_clock::now() > timeout_time);
-    });
+    bool cancelled, locked, timed_out;
+    {
+      std::unique_lock<std::mutex> lock(this->fineacquire_mtx);
+      this->fineacquire_cv.wait(lock, [&]() {
+          if ( this->is_fineacquire_running.load() ) was_running = true;
+          return this->is_fineacquire_locked.load() || this->cancel_flag.load() ||
+                 ( was_running && !this->is_fineacquire_running.load() ) ||
+                 (use_timeout && std::chrono::steady_clock::now() > timeout_time);
+      });
+      // Classify the outcome while still holding the mutex. is_fineacquire_*
+      // are written under this mutex by handletopic_slicecamd(); releasing
+      // first would let a late publish flip them between here and the checks
+      // (e.g. a stale "locked" arriving after a timeout wake, making a
+      // timed-out run look successful and skipping the stop).
+      cancelled = this->cancel_flag.load();
+      locked    = this->is_fineacquire_locked.load();
+      timed_out = use_timeout && std::chrono::steady_clock::now() >= timeout_time;
+    }  // release fineacquire_mtx before do_slicecam_stop() below (it locks the same mutex)
 
-    if (this->cancel_flag.load()) return ABORT;
+    if (cancelled) return ABORT;
 
-    // Determine outcome by reading state. If not locked, then this is a
-    // failure of some kind; distinguish a true timeout from slicecamd
-    // stopping without locking by consulting the clock. This ordering
-    // ensures that a failure publish arriving at or near the timeout
-    // boundary is still reported as a failure (not mis-labeled as a
-    // timeout).
+    // If not locked this is a failure of some kind; distinguish a true timeout
+    // from slicecamd stopping without locking. A failure at/near the timeout
+    // boundary is still reported as a failure, not mis-labeled as a timeout.
     //
-    if (!this->is_fineacquire_locked.load()) {
-      if (use_timeout && std::chrono::steady_clock::now() >= timeout_time) {
-        logwrite( function, "ERROR slicecam fine acquisition timed out!" );
+    if (!locked) {
+      if (timed_out) {
+        logwrite( function, "ERROR slicecam fine acquisition timed out; aborting" );
+        this->do_slicecam_stop();  // stop the running loop so it can't perturb the exposure
         return TIMEOUT;
       }
       logwrite( function, "ERROR slicecam fine acquisition stopped without locking" );

--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -2589,6 +2589,22 @@ namespace Slicecam {
       return ERROR;
     }
 
+    // Lock out user-initiated moves while ACAM is acquiring (converging on the
+    // target). Jog (LEFT/RIGHT/UP/DOWN), put-on-slit and put-on-guider on both
+    // GUIs all arrive here via "scam putonslit"; a manual move mid-acquisition
+    // would disrupt it. Ask acamd for its mode directly; moves are allowed
+    // while guiding or stopped, only blocked while actively acquiring.
+    //
+    {
+      std::string acam_mode;
+      if ( this->acamd.command( ACAMD_ACQUIRE, acam_mode ) == NO_ERROR &&
+           acam_mode.find("acquiring") != std::string::npos ) {
+        logwrite( function, "ERROR cannot move while ACAM is acquiring" );
+        retstring="acquiring";
+        return ERROR;
+      }
+    }
+
     // outputs: result from solve_offset in degrees
     //
     double ra_off, dec_off;


### PR DESCRIPTION
Two small, related acquisition-robustness fixes.

## 1. Stop slicecam fineacquire on timeout (`sequence_acquisition.cpp`)

`do_slicecam_fineacquire` returned `TIMEOUT` but left slicecamd's fineacquire loop **running**. If the observer continues past the warning, that lingering loop keeps sending guide-goal offsets to ACAM **during the science exposure**, perturbing it. `move_to_target` (new target) and `abort_process` (user abort) already stop fineacquire, but neither covers this window. On timeout it now calls `do_slicecam_stop()`.

The outcome (`cancelled`/`locked`/`timed_out`) is **classified while still holding `fineacquire_mtx`** — those flags are written under that mutex by `handletopic_slicecamd()`, so reading them after releasing could misclassify a timed-out run as success (and skip the stop) if a late publish arrived. The lock is released only before `do_slicecam_stop()` (which locks the same mutex). *(addresses the P2 review note.)*

## 2. Lock out user-initiated moves while ACAM is acquiring (`slicecam`/`acam put_on_slit`)

A manual telescope move during ACAM acquisition disrupts the convergence. Moves are now rejected while ACAM's mode is `acquiring` (`TARGET_ACQUIRE`/`ACQUIRE_HERE`); allowed while guiding or stopped.

- **`slicecam put_on_slit`** — the single entry for every GUI move that uses `scam putonslit`: **jog LEFT/RIGHT/UP/DOWN, put-on-slit, and put-on-guider on both the ACAM and SCAM ds9 GUIs**. Queries acamd's mode directly and rejects when acquiring. Placed in `put_on_slit` (not `offset_acam_goal`) to stay conflict-free with the in-flight put-on-slit-routing PRs.
- **`acam put_on_slit`** — the "offset guider" button (`acam putonslit`); checks the local `acquire_mode`.

## Notes
- The sequencer's `acquisition_timeout` itself already *fires* (via slicecamd's 60 s temperature heartbeat on `Topic::SLICECAMD` waking the cv); this PR adds the missing **stop** on timeout, not the timeout itself.
- Not compiled locally (no local build available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)