### PR TITLE
fix: slicecam guiding flag reads wrong field

### DIFF
--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -875,10 +875,10 @@ namespace Slicecam {
     std::lock_guard<std::mutex> lock(snapshot_mtx);
     snapshot_status[Topic::ACAMD]=true;
     }
-    // set is_acam_guiding flag
-    bool acquired = false;
-    Common::extract_telemetry_value( jmessage, Key::Acamd::IS_ACQUIRED, acquired );
-    this->is_acam_guiding.store(acquired, std::memory_order_relaxed);
+    // set is_acam_guiding from ACAM's acquire mode
+    std::string mode;
+    Common::extract_telemetry_value( jmessage, Key::Acamd::ACQUIRE_MODE, mode );
+    this->is_acam_guiding.store(mode=="guiding", std::memory_order_relaxed);
 
     // acam's publish time
     int64_t pubtime=0;


### PR DESCRIPTION
Problem:
"_Put on slit_" intermittently fails when acam guiding is off (telescope doesn't move and command silently does nothing).

Cause:
If acam is not guiding then slicecam can send offsets directly to the TCS. But if it is guiding, then it changes acam's goal.
I was reading the `is_acam_guiding` state by looking at the message key `Key::Acamd::IS_ACQUIRED` but that is true (and stays true) after an acquisition, whether or not we are currently guiding. So it could read "_guiding_" when actually not guiding. The intermittent part is the occasional acquired-but-not-guiding window.

Fix:
populate the flag from `Key::Acamd::ACQUIRE_MODE` which contains { `standby`  `acquire`  `guiding`  }

This replaces PR https://github.com/CaltechOpticalObservatories/NGPS/pull/450. That applied a band-aid which masked the true problem.