### PR TITLE
removed extraneous line setting EXPTIME key on shutter closure

### DIFF
--- a/camerad/astrocam.cpp
+++ b/camerad/astrocam.cpp
@@ -2127,7 +2127,6 @@ namespace AstroCam {
     // These have to be added to fitsinfo[expbuf] because the exposure has already started,
     // and camera_info keys have already been locked-in to fitsinfo[].
     //
-    interface.fitsinfo[expbuf]->systemkeys.primary().addkey( "EXPSTART", timestring, "exposure start time" );
     interface.fitsinfo[expbuf]->systemkeys.primary().addkey( "MJD0", mjd0, "exposure start time (modified Julian Date)" );
     interface.fitsinfo[expbuf]->systemkeys.primary().addkey( "MJD1", mjd1, "exposure stop time (modified Julian Date)" );
     interface.fitsinfo[expbuf]->systemkeys.primary().addkey( "MJD", mjd, "average of MJD0 and MJD1" );


### PR DESCRIPTION
solves issue https://github.com/CaltechOpticalObservatories/NGPS/issues/461