### PR TITLE
slicecamd: anchor the fine-acquire settle to the executed TCS move, not a timer

### DIFF
--- a/Config/slicecamd.cfg.in
+++ b/Config/slicecamd.cfg.in
@@ -98,6 +98,13 @@ FINE_ACQUIRE_SETTLE_FRAMES=2
 #
 FINE_ACQUIRE_SETTLE_SEC=3.0
 
+# FINE_ACQUIRE_MOVE_TIMEOUT=<sec>
+# Max time <sec> to wait for acamd to report a requested goal change applied
+# before the settle begins. On timeout the settle proceeds anyway. Set to 0
+# to disable the wait.
+#
+FINE_ACQUIRE_MOVE_TIMEOUT=60.0
+
 # FINE_ACQUIRE_GAIN=<g>
 # Proportional gain <g> = {0..1} applied to the commanded offset when the residual
 # is at or below FINE_ACQUIRE_GAIN_THRESHOLD arcsec.

--- a/Config/slicecamd.cfg.in
+++ b/Config/slicecamd.cfg.in
@@ -86,9 +86,10 @@ FINE_ACQUIRE_MIN_SAMPLES=3
 
 # FINE_ACQUIRE_SETTLE_FRAMES=<n>
 # <n> frames discarded after each telescope move to allow settling before
-# centroid measurements resume.
+# centroid measurements resume. The wall-clock settle (FINE_ACQUIRE_SETTLE_SEC,
+# applied after acamd confirms the goal change) covers the move itself.
 #
-FINE_ACQUIRE_SETTLE_FRAMES=2
+FINE_ACQUIRE_SETTLE_FRAMES=0
 
 # FINE_ACQUIRE_SETTLE_SEC=<sec>
 # Time-based settle <sec> applied after each move, in addition to SETTLE_FRAMES,

--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -1443,6 +1443,7 @@ namespace Acam {
     const int         attempts     = this->target.attempts;
     const std::string filter       = this->motion.get_current_filtername();
     const std::string cover        = this->motion.get_current_coverpos();
+    const bool        goalshift_pending = this->target.goalshift_pending.load();
 
     // unless forced, only publish if there was a change in any one of these
     //
@@ -1452,7 +1453,8 @@ namespace Acam {
          nacquired    == this->last_status.nacquired    &&
          attempts     == this->last_status.attempts     &&
          filter       == this->last_status.filter       &&
-         cover        == this->last_status.cover ) return;
+         cover        == this->last_status.cover        &&
+         goalshift_pending == this->last_status.goalshift_pending ) return;
 
     this->last_status.acquire_mode = acquire_mode;
     this->last_status.is_acquired  = is_acquired;
@@ -1460,6 +1462,7 @@ namespace Acam {
     this->last_status.attempts     = attempts;
     this->last_status.filter       = filter;
     this->last_status.cover        = cover;
+    this->last_status.goalshift_pending = goalshift_pending;
 
     // assemble the telemetry into a json message
     //
@@ -1473,6 +1476,7 @@ namespace Acam {
     jmessage_out[Key::Acamd::BACKGROUND]   = this->astrometry.get_background();
     jmessage_out[Key::Acamd::FILTER]       = filter;
     jmessage_out[Key::Acamd::COVER]        = cover;
+    jmessage_out[Key::Acamd::GOALSHIFT_PENDING] = goalshift_pending;
     jmessage_out[Key::PUBTIME] = get_time_us();
 
     try {
@@ -3609,10 +3613,13 @@ logwrite( function, message.str() );
         offset = angular_separation( acam_goal.ra, acam_goal.dec, acam_ra, acam_dec );
       }
 *****/
+      const bool goal_change_at_compute = this->goalshift_pending.load(std::memory_order_acquire);
+      const double goal_ra_used  = this->acam_goal.ra;
+      const double goal_dec_used = this->acam_goal.dec;
       if ( iface->fpoffsets.solve_offset( acam_ra, acam_dec,
-                                          this->acam_goal.ra, this->acam_goal.dec,
+                                          goal_ra_used, goal_dec_used,
                                           ra_off, dec_off ) == ERROR ) break;
-      offset = angular_separation( this->acam_goal.ra, this->acam_goal.dec, acam_ra, acam_dec );
+      offset = angular_separation( goal_ra_used, goal_dec_used, acam_ra, acam_dec );
 
         message.str(""); message << "[DEBUG] acam_ra=" << acam_ra << " acam_dec=" << acam_dec << " acam_goal.ra=" 
                                  << acam_goal.ra << "  .dec=" << this->acam_goal.dec << " .ang=" << this->acam_goal.angle;
@@ -3692,6 +3699,11 @@ logwrite( function, message.str() );
           // send offset to TCS here (returns when offset is complete)
           if ( iface->tcsd.pt_offset( ra_off*3600., dec_off*3600., OFFSETRATE )==ERROR) break;
           this->allow_large_offset.store(false);  // deliberate-offset allowance consumed
+          if ( goal_change_at_compute &&
+               goal_ra_used  == this->acam_goal.ra &&
+               goal_dec_used == this->acam_goal.dec ) {
+            this->goalshift_pending.store( false, std::memory_order_release );
+          }
           std::this_thread::sleep_for( std::chrono::seconds(1) );
         }
 
@@ -5530,6 +5542,8 @@ logwrite( function, message.str() );
     //
     this->fpoffsets.apply_offset( this->target.acam_goal.ra,  this->target.dRA,
                                   this->target.acam_goal.dec, this->target.dDEC );
+    this->target.goalshift_pending.store( true, std::memory_order_release );
+    this->publish_status(true);
 
 
     message.str(""); message << this->target.dRA << " " << this->target.dDEC;

--- a/acamd/acam_interface.h
+++ b/acamd/acam_interface.h
@@ -349,6 +349,7 @@ namespace Acam {
 
       std::atomic<bool> is_acquired;       ///< set if target acquired successfully
       std::atomic<bool> stop_acquisition;  ///< set if the acquisition sequence should stop
+      std::atomic<bool> goalshift_pending{false};  ///< a requested goal change awaits execution by the guide loop
 
       double tcs_max_offset;
       double tcs_max_putonslit_offset{300.};  ///< max offset (arcsec) for a deliberate goal offset (put-on-slit etc.) applied while guiding; defaults 300 if ACQUIRE_TCS_MAX_PUTONSLIT_OFFSET absent
@@ -530,6 +531,7 @@ namespace Acam {
         int         attempts     = 0;
         std::string filter       = "";
         std::string cover        = "";
+        bool        goalshift_pending = false;
       } last_status;
 
     public:

--- a/common/message_keys.h
+++ b/common/message_keys.h
@@ -106,6 +106,7 @@ namespace Key {
     inline const std::string ATTEMPTS     = "attempts";
     inline const std::string SEEING       = "seeing";
     inline const std::string BACKGROUND   = "background";
+    inline const std::string GOALSHIFT_PENDING = "goalshift_pending";  ///< a requested goal change awaits execution by the guide loop
   }
 
   namespace Slicecamd {

--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -423,6 +423,39 @@ namespace Slicecam {
     const int max_samples = this->fineacquire_state.max_samples;
     const int min_samples = this->fineacquire_state.min_samples;
 
+    // Verification pass, accept-only early exit: once a correction has been
+    // applied this run, a single frame already inside the goal is sufficient
+    // proof. A frame may only ACCEPT -- anything larger falls through to the
+    // usual median machinery, so a noisy frame can never trigger a
+    // correction or an extra cycle.
+    //
+    if ( this->fineacq_total_dra != 0.0 || this->fineacq_total_ddec != 0.0 ) {
+      const double r1 = std::hypot( offsets.first, offsets.second ) * 3600.0;
+      if ( r1 <= this->fineacquire_state.goal_arcsec ) {
+        std::ostringstream oss;
+        oss << "fine acquisition converged: single-frame offset r=" << r1
+            << " arcsec <= goal=" << this->fineacquire_state.goal_arcsec
+            << " arcsec (n=" << n << ")";
+        logwrite( function, oss.str() );
+
+        std::ostringstream acqmodel;
+        acqmodel << "[ACQMODEL] acam2slit dRA=" << this->fineacq_total_dra
+                 << " dDEC="     << this->fineacq_total_ddec << " arcsec"
+                 << " GOALRA="   << this->fineacq_goal_ra
+                 << " GOALDEC="  << this->fineacq_goal_dec
+                 << " CASANGLE=" << this->telem.angle_scope
+                 << " n="        << n
+                 << " cam="      << which;
+        logwrite( function, acqmodel.str() );
+
+        this->is_fineacquire_locked.store( true,  std::memory_order_release );
+        this->is_fineacquire_running.store( false,  std::memory_order_release );
+        this->fineacquire_state.reset();
+        this->publish_status();
+        return;
+      }
+    }
+
     // wait for the minimum number of samples before evaluating anything
     //
     if ( n < min_samples ) return;

--- a/slicecamd/slicecam_interface.cpp
+++ b/slicecamd/slicecam_interface.cpp
@@ -60,6 +60,10 @@ namespace Slicecam {
       const bool was_running = this->is_fineacquire_running.load(std::memory_order_acquire);
       this->is_fineacquire_locked.store(false, std::memory_order_release);
       this->is_fineacquire_running.store(false, std::memory_order_release);
+      {
+      std::lock_guard<std::mutex> lock(this->acam_mtx);
+      this->acam_cv.notify_all();
+      }
       this->publish_status();
       logwrite(function, was_running ? "stop requested" : "stopped");
       retstring=this->is_fineacquire_running.load(std::memory_order_acquire)?"running":"stopped";
@@ -562,11 +566,44 @@ namespace Slicecam {
     const double cmd_dra  = effective_gain * med_dra;
     const double cmd_ddec = effective_gain * med_ddec;
 
+    const int64_t send_time = get_time_us();
+    const bool was_guiding = this->is_acam_guiding.load();
+
     if ( this->offset_acam_goal( { cmd_dra, cmd_ddec }, true ) != NO_ERROR ) {
       logwrite( function, "ERROR failed to send offset to ACAM" );
       this->is_fineacquire_running.store( false, std::memory_order_release );
       this->publish_status();
       return;
+    }
+
+    // while guiding the correction only re-points acamd's goal; wait until
+    // acamd reports the goal change applied before settling
+    if ( was_guiding && this->fineacquire_state.move_timeout_sec > 0.0 ) {
+      std::unique_lock<std::mutex> lock(this->acam_mtx);
+      // completion requires seeing THIS request registered (pending true on a
+      // status after the send) and then cleared; statuses arrive in publish
+      // order, so the false cannot predate the request
+      bool seen_pending = false;
+      const bool applied = this->acam_cv.wait_for( lock,
+          std::chrono::duration<double>( this->fineacquire_state.move_timeout_sec ),
+          [this, send_time, &seen_pending]() {
+            if ( !this->is_fineacquire_running.load(std::memory_order_acquire) ||
+                 !this->should_framegrab_run.load(std::memory_order_acquire) ) return true;
+            if ( this->last_acam_pubtime.load(std::memory_order_acquire) <= send_time ) return false;
+            if ( this->acam_goalshift_pending.load(std::memory_order_acquire) ) {
+              seen_pending = true;
+              return false;
+            }
+            return seen_pending;
+          });
+      if ( !this->should_framegrab_run.load(std::memory_order_acquire) ) return;
+      if ( !this->is_fineacquire_running.load(std::memory_order_acquire) ) return;
+      if ( !applied ) {
+        std::ostringstream w;
+        w << "WARNING goal change not applied within "
+          << this->fineacquire_state.move_timeout_sec << " s; proceeding";
+        logwrite( function, w.str() );
+      }
     }
 
     // time-based settle: wait for the TCS to physically finish the move before
@@ -923,6 +960,10 @@ namespace Slicecam {
     int64_t pubtime=0;
     Common::extract_telemetry_value( jmessage, Key::PUBTIME, pubtime );
     this->last_acam_pubtime.store( pubtime, std::memory_order_relaxed );
+
+    bool goalshift_pending=false;
+    Common::extract_telemetry_value( jmessage, Key::Acamd::GOALSHIFT_PENDING, goalshift_pending );
+    this->acam_goalshift_pending.store( goalshift_pending, std::memory_order_relaxed );
 
     // wake any thread waiting on ACAM state (e.g. fineacquire)
     std::lock_guard<std::mutex> lock(this->acam_mtx);
@@ -1409,6 +1450,19 @@ namespace Slicecam {
         try { this->fineacquire_state.settle_sec = std::stod( config.arg[entry] ); }
         catch ( const std::exception &e ) {
           message.str(""); message << "ERROR invalid FINE_ACQUIRE_SETTLE_SEC "
+                                   << config.arg[entry] << ": " << e.what();
+          logwrite( function, message.str() );
+          return ERROR;
+        }
+        message.str(""); message << "SLICECAMD:config:" << config.param[entry] << "=" << config.arg[entry];
+        logwrite( function, message.str() );
+        applied++;
+      }
+      else
+      if ( config.param[entry] == "FINE_ACQUIRE_MOVE_TIMEOUT" ) {
+        try { this->fineacquire_state.move_timeout_sec = std::stod( config.arg[entry] ); }
+        catch ( const std::exception &e ) {
+          message.str(""); message << "ERROR invalid FINE_ACQUIRE_MOVE_TIMEOUT "
                                    << config.arg[entry] << ": " << e.what();
           logwrite( function, message.str() );
           return ERROR;
@@ -2101,6 +2155,10 @@ namespace Slicecam {
     //
     if ( whattodo == "stop" ) {
       this->should_framegrab_run.store( false, std::memory_order_release );  // tells framegrab loop to stop
+      {
+      std::lock_guard<std::mutex> lock(this->acam_mtx);
+      this->acam_cv.notify_all();
+      }
       if ( this->is_framegrab_running.load(std::memory_order_acquire) ) {    // wait for it to stop
         int wait_ms = std::max( static_cast<int>(3000*(this->camera.andor.begin()->second->camera_info.exptime+1)), 5000 );
         // alert user that framegrabbing has stopped
@@ -2180,6 +2238,10 @@ namespace Slicecam {
       // frame will be grabbed.
       //
       this->should_framegrab_run.store( false, std::memory_order_release );
+      {
+      std::lock_guard<std::mutex> lock(this->acam_mtx);
+      this->acam_cv.notify_all();
+      }
       if ( this->is_framegrab_running.load(std::memory_order_acquire) ) return;
     }
     else
@@ -2596,6 +2658,10 @@ namespace Slicecam {
     //
     bool is_guiding = this->is_acam_guiding.load();
 
+    // arcsec for the log; the guiding path sends degrees
+    const double ra_off_arcsec  = ra_off  * 3600.;
+    const double dec_off_arcsec = dec_off * 3600.;
+
     // send the offsets now
     //
     if ( is_guiding ) {
@@ -2632,7 +2698,7 @@ namespace Slicecam {
     }
 
     std::ostringstream message;
-    message << "requested offsets dRA=" << ra_off << " dDEC=" << dec_off << " arcsec";
+    message << "requested offsets dRA=" << ra_off_arcsec << " dDEC=" << dec_off_arcsec << " arcsec";
     logwrite(function, message.str());
 
     return NO_ERROR;

--- a/slicecamd/slicecam_interface.h
+++ b/slicecamd/slicecam_interface.h
@@ -95,6 +95,7 @@ namespace Slicecam {
     int    settle_frames = 0;       ///< countdown of frames to discard while telescope settles
     int    settle_count  = 2;       ///< configured: frames to discard after each move
     double settle_sec    = 3.0;     ///< time-based settle (sec) after each move; 0 disables (needed when autoexpose shortens frames so the frame-count settle is too brief in wall-clock)
+    double move_timeout_sec = 60.0; ///< max wait (sec) for acamd to report the goal change applied; 0 disables the wait
     int    consecutive_centroid_failures = 0; ///< counts consecutive centroid failures
     // exposure compensation (shared by the reactive trim and, later, autoexpose)
     double exptime_min     = 0.1;   ///< clamp: minimum auto-adjusted exposure (sec)
@@ -193,6 +194,7 @@ namespace Slicecam {
       std::atomic<bool> is_acam_guiding;         ///< is acam guiding?
 
       std::atomic<int64_t> last_acam_pubtime{0};   ///< pubtime (us) of latest received acamd status
+      std::atomic<bool> acam_goalshift_pending{false};  ///< acamd has an unexecuted goal change
 
       // Latest target (goal) coords published on Topic::TARGETINFO
       // NAN until a TARGETINFO arrives, so manual runs with no sequencer target log nan.


### PR DESCRIPTION

## THIS FIXES A _CRITICAL_ BUG (measured, UT 2026-08-06 07:50, BD+28d4211)

Fine-acquire corrections do not move the telescope: `offset_acam_goal` sends
`offsetgoal <dRA> <dDEC> fineguiding` to acamd, which only shifts the guide
GOAL — the physical `pt_offset` happens at acamd's **next guide solve**, up to
one full guide cycle (ACAM exptime + ~few s) later. slicecamd's post-correction
settle is currently a fixed 3 s sleep anchored at the **send** (`FINE_ACQUIRE_SETTLE_SEC`,
slicecam_interface.cpp:576-578), followed by 2 skipped frames and 3 fresh
samples. This works fine most of the time, but very short slicecam exposure times in combination with longer exposure times set on acam WILL lead to a situation where all of the slicecam safety and wait logic
completes before the telescope actually moves. This WILL result in a double offset by fineacquire, which can in a very unfortunate case also lead to a fineacquire 'lock' in between these two guide goal changes. Result is that the star is NOT centered on exposure.

On 2026-08-06 the per-frame log shows this end to end:

- 07:50:25.320 — measurement 1: dRA=−1.035 dDEC=−2.429 (r=2.64″) → goal shift 1 sent
- 07:50:31.013 — tcsd receives `offset -0.983478 -2.485729 40` (move 1, 5.7 s after the send); DONE 31.893
- 07:50:30.630 / 31.408 / 32.173 — measurement 2's three frames: the first two show the star at the **identical pre-move pixel (160,112)**
- 07:50:32.173 — measurement 2: dRA=−0.931 dDEC=−2.388 (r=2.56″) — the same error re-measured from stale sky → goal shift 2 sent
- 07:50:38.358 — tcsd receives `offset -0.902148 -2.568997 40` (move 2 — the double application)
- 07:50:39.059 — "converged r=0.249″" (star genuinely on the aimpoint after move 1 alone) — 0.13 s before move 2 completes and drags it off
- During the following three exposures acamd's during-exposure plate solve puts the field at DEC 28.877943 — **0.068″ from the doubly-shifted goal**, i.e. the guide loop held the star ~2.6″ off the slit, locked  on the wrong spot.
- All three frames of the V=10.5 standard extracted at SNR −1.5 to −2.5 (expected ~400–500). 

Prevalence: 1 confirmed double in 109 fine sessions scanned — rare because the
typical guide cadence (~5 s) beats the ~6 s fineacquire re-measure time, but the odds rise
toward certainty in the combination when ACAM exposures lengthen (poor transparency) while bright
stars keep slicecam frames short. 

## The fix (add a real check for guide goal change instead of the fixed wait in fineacquire)

1. **acamd** tracks the request: `offsetgoal` marks the goal change
   *pending*; the guide loop clears it when it executes a correction computed
   from the changed goal (the pending state is captured before the goal is
   read, so a correction already in flight can never clear it — and since
   every correction is `goal − actual position`, executing one computed from
   the new goal lands the telescope at the new goal). The flag is published
   in the existing status.
2. **slicecamd**: `do_fineacquire` waits until acamd reports the goal change
   applied (pending false, on a status newer than the send) before
   `FINE_ACQUIRE_SETTLE_SEC` (now a true post-move settle) and fresh
   sampling. A stop interrupts the wait. Timeout `FINE_ACQUIRE_MOVE_TIMEOUT`
   (default 60 s, cfg.in knob; 0 disables): proceed with a WARNING —
   fail-open, never a hang.
3. This also removes the converged-while-a-shift-is-in-flight defect for
   free: no sample any decision uses can predate the move it follows.
4. Ride-along log fix: `offset_acam_goal`'s "requested offsets … arcsec"
   line printed **degrees** while guiding (the ×3600 sits in the non-guiding
   branch only, slicecam_interface.cpp:2619-2636). Log now prints arcsec on
   both paths; nothing sent to acamd changes.

## Notes for the reviewer

- Config lives in `slicecamd.cfg.in` (the deployed .cfg is cmake output and
  is regenerated on rebuild — the June 22 aimpoint/gain revert).
- Not compiled locally (no build environment); build on the instrument.
- Acceptance after deployment: scrape a night's fine sessions and check every
  post-correction sampling gap sits after its move-DONE; the robot's
  completion-audit race detector stays armed as the regression alarm either
  way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
