### PR TITLE
restore acamd.cfg.in to use real motor instead of emulator

### DIFF
--- a/Config/acamd.cfg.in
+++ b/Config/acamd.cfg.in
@@ -100,9 +100,9 @@ PUSH_GUIDER_MESSAGE=/home/developer/Software/GuiderGUI/message.sh
 # For acamd, one controller must be named "filter" and the other must be named "cover"
 #
 MOTOR_CONTROLLER="filter @IP_ETS8P@ @ETS8P_ACAM_MOTION@ 1 1"
-#MOTOR_CONTROLLER="cover  @IP_ETS8P@ @ETS8P_ACAM_MOTION@ 2 1"
+MOTOR_CONTROLLER="cover  @IP_ETS8P@ @ETS8P_ACAM_MOTION@ 2 1"
 #MOTOR_CONTROLLER="filter localhost @ACAMD_EMULATOR@ 1 1"     # emulator
-MOTOR_CONTROLLER="cover  localhost @ACAMD_EMULATOR@ 2 1"     # emulator
+#MOTOR_CONTROLLER="cover  localhost @ACAMD_EMULATOR@ 2 1"     # emulator
 
 # For each actuator's controller specify:
 # MOTOR_AXIS="<name> <axis> <min> <max> <zero> <ref>"


### PR DESCRIPTION
replaced a faulty serial cable today, restoring acam cover functionality