### PR TITLE
URGENT (one-line fix): deliberate offsets must not be gated on guide mode — wrong-object exposure

### DIFF
--- a/acamd/acam_interface.cpp
+++ b/acamd/acam_interface.cpp
@@ -3644,7 +3644,10 @@ logwrite( function, message.str() );
       // and is unaffected.
       //
       double maxoffset = this->tcs_max_offset;
-      if ( this->acquire_mode == Acam::TARGET_GUIDE && this->allow_large_offset.load() ) {
+      if ( this->allow_large_offset.load() ) {
+        // A deliberate goal offset is correct by construction and must not
+        // be capped as a guide correction, whatever mode the loop is in
+        // when the correction lands.
         maxoffset = this->tcs_max_putonslit_offset;
       }
 


### PR DESCRIPTION
**URGENT — one-line fix.** A wrong-object science exposure occurred on sky tonight; any offset-star target with a separation above 60″ can silently expose the wrong object until this lands.


## The failure, measured on sky (UT 2026-08-26 10:37, ZTF26abicncn)

The end-of-fineacquire science offset (72″, star → target) was commanded
via `offsetgoal` 6 ms after fine-acquire convergence. The large-offset
allowance (`allow_large_offset`, the ACQUIRE_TCS_MAX_PUTONSLIT_OFFSET=300″
path that exists exactly for deliberate offsets) was armed correctly — but
the cap selection also required `acquire_mode == TARGET_GUIDE`, and the
loop had not yet transitioned. The armed allowance was ignored and the
offset was refused against the 60″ guide cap, five times:

    [WARNING] calculated offset 72.2476 not below max 60 and will not be sent to the TCS
    ...
    ERROR: failed to find offset below 60 within max number of attempts

The guide loop then died and 900 s were exposed at the star pointing — a
clean spectrum of the G=16.3 offset star instead of the science target.
Every other same-night offset above 60″ (up to 123″) whose command landed
seconds — rather than milliseconds — after convergence executed normally:
the mode gate is a race, and this target lost it.

## The change (one condition)

`Acam::Target::do_acquire`, cap selection: the allowance applies whatever
mode the loop is in when the correction lands. A deliberate goal offset
(put-on-slit, offset-star acquisition, the end-of-fineacquire target
offset, the pyGUI 'Offset' button) is correct by construction; capping it
as if it were a guide correction refuses the science.

## Why this adds no risk

The allowance is one-shot: armed only by a deliberate `offsetgoal` (never
by acquisition or guiding itself) and consumed by the next correction,
on use or on rejection. Ordinary guide corrections therefore remain capped
at ACQUIRE_TCS_MAX_OFFSET (60″) in every mode, exactly as before; the
absolute 300″ backstop also still applies. The only behavioral change is
that the one deliberate correction can no longer be mistaken for a guide
correction by arriving at the wrong millisecond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
